### PR TITLE
Fix sidebar visibility on auth pages

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import SidePanel from "../components/ui/side-panel";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { AuthProvider, useAuth } from "@/lib/api/authContext";
 import { useEffect } from "react";
 
@@ -27,12 +27,15 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const pathname = usePathname();
+  const showSidePanel =
+    pathname !== "/auth/login" && pathname !== "/auth/signIn";
   return (
     <html data-theme="emerald" lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <AuthProvider>
           <AuthGuard>
-            <SidePanel>{children}</SidePanel>
+            {showSidePanel ? <SidePanel>{children}</SidePanel> : children}
           </AuthGuard>
         </AuthProvider>
       </body>


### PR DESCRIPTION
## Summary
- prevent the sidebar from rendering on login or registration pages

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `python manage.py test` *(fails: `ModuleNotFoundError: No module named 'django'`)*

------
https://chatgpt.com/codex/tasks/task_e_684075bd74688331a5eef55a7234d6f1