### PR TITLE
Improve authentication flow and profile

### DIFF
--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -2,8 +2,9 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { login } from "@/lib/api/auth";
-import { useAuth } from "@/lib/store/auth";
+import { login as loginApi } from "@/lib/api/auth";
+import { useAuth } from "@/lib/api/authContext";
+import { useRouter } from "next/navigation";
 import { Input } from "@/components/ui/Input";
 import { toast } from "@/components/ui/toast";
 import "@/app/globals.css";
@@ -16,7 +17,8 @@ const schema = z.object({
 type FormData = z.infer<typeof schema>;
 
 export default function LoginPage() {
-  const setUser = useAuth((s) => s.setUser);
+  const { login } = useAuth();
+  const router = useRouter();
   const {
     register,
     handleSubmit,
@@ -25,10 +27,11 @@ export default function LoginPage() {
 
   const onSubmit = async (data: FormData) => {
     try {
-      const response = await login(data);
-      const user = { id: response.user.id, username: response.user.username }; // Ensure the response matches the expected type
-      setUser(user);
+      const response = await loginApi(data);
+      localStorage.setItem("token", response.access);
+      login(response.user);
       toast.success("Connexion réussie");
+      router.push("/");
     } catch {
       toast.error("Identifiants incorrects");
     }

--- a/web/src/app/auth/signIn/page.tsx
+++ b/web/src/app/auth/signIn/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { registerAlumni, registerStudent } from "@/lib/api/auth";
+import { registerAlumni, registerStudent, login as loginApi } from "@/lib/api/auth";
+import { useAuth } from "@/lib/api/authContext";
+import { useRouter } from "next/navigation";
 import axios from "axios";
-import { arrayOutputType, object } from "zod";
 
 export default function SignIn() {
+  const { login } = useAuth();
+  const router = useRouter();
   // États de base
   const [userType, setUserType] = useState<"student" | "alumni">("alumni");
   const [isPasswordEqual, setIsPasswordEqual] = useState(true);
@@ -176,7 +179,13 @@ export default function SignIn() {
 
       // 4. Succès (2xx)
       console.log("Réponse succès :", res.data);
-      alert("Inscription réussie !");
+      const loginRes = await loginApi({
+        email: user.email,
+        password: user.password,
+      });
+      localStorage.setItem("token", loginRes.access);
+      login(loginRes.user);
+      router.push("/");
     } catch (err) {
       if (axios.isAxiosError(err) && err.response) {
         const { status, data } = err.response;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -46,12 +46,13 @@ export default function RootLayout({
 function AuthGuard({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
-    if (!loading && !user) {
+    if (!loading && !user && pathname !== "/auth/signIn") {
       router.push("/auth/login");
     }
-  }, [loading, user, router]);
+  }, [loading, user, pathname, router]);
 
   if (loading) {
     return null;

--- a/web/src/components/ui/personal-profile.tsx
+++ b/web/src/components/ui/personal-profile.tsx
@@ -3,26 +3,30 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Edit2 as Pencil } from "lucide-react";
 import { motion } from "framer-motion";
+import { useAuth } from "@/lib/api/authContext";
 
 interface ProfileField {
   label: string;
   value: string;
 }
 
-const initialFields: ProfileField[] = [
-  { label: "Username", value: "Fab123" },
-  { label: "Email", value: "fab@gmail.com" },
-  { label: "Prenoms", value: "Fabien" },
-  { label: "Nom", value: "Konaré" },
-  { label: "Secteur", value: "Informatique" },
-  { label: "Emploie", value: " Developpeur web" },
-];
+function buildFields(user: any): ProfileField[] {
+  if (!user) return [];
+  return [
+    { label: "Username", value: user.username },
+    { label: "Email", value: user.email },
+    { label: "Prenoms", value: user.prenom },
+    { label: "Nom", value: user.nom },
+    { label: "Role", value: user.role },
+  ];
+}
 
 interface PersonalProfileProps {
   onClose: () => void;
 }
 export default function PersonalProfile({ onClose }: PersonalProfileProps) {
-  const [fields, setFields] = useState<ProfileField[]>(initialFields);
+  const { user } = useAuth();
+  const [fields, setFields] = useState<ProfileField[]>(buildFields(user));
   const [editing, setEditing] = useState<string | null>(null);
   const [showButton, setShowButton] = useState(false);
 
@@ -55,6 +59,10 @@ export default function PersonalProfile({ onClose }: PersonalProfileProps) {
       document.removeEventListener("keydown", handleEscKey);
     };
   }, [onClose]);
+
+  useEffect(() => {
+    setFields(buildFields(user));
+  }, [user]);
 
   return (
     <div

--- a/web/src/lib/api/axios.tsx
+++ b/web/src/lib/api/axios.tsx
@@ -8,7 +8,15 @@ export const api = axios.create({
 
 // Intercepteur : attache automatiquement le JWT (stocké en cookie httpOnly)
 api.interceptors.request.use((config) => {
-  // Ex : lecture d’un token CSRF si besoin
+  if (typeof window !== "undefined") {
+    const token = localStorage.getItem("token");
+    if (token) {
+      config.headers = {
+        ...config.headers,
+        Authorization: `Bearer ${token}`,
+      };
+    }
+  }
   return config;
 });
 


### PR DESCRIPTION
## Summary
- attach JWT token from localStorage in axios requests
- handle login using auth context and store token
- auto login user after registration
- prevent signup page from redirecting to login
- display current user info in profile panel

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684457778f548331b6ad557ea24ea3f2