### PR TITLE
Connect profile update to backend

### DIFF
--- a/web/src/lib/api/auth.tsx
+++ b/web/src/lib/api/auth.tsx
@@ -26,3 +26,19 @@ export async function registerAlumni(data: AlumniRegisterPayload) {
   );
   return res;
 }
+
+export async function updateProfile(data: Partial<{
+  username: string;
+  nom: string;
+  prenom: string;
+  photo_profil: string | null;
+  biographie: string | null;
+}>) {
+  const res = await api.put("/accounts/me/update/", data);
+  return res.data;
+}
+
+export async function changeEmail(data: { email: string }) {
+  const res = await api.put("/accounts/change-email/", data);
+  return res.data;
+}

--- a/web/src/types/auth.d.ts
+++ b/web/src/types/auth.d.ts
@@ -43,7 +43,7 @@ export interface StudentRegisterPayload {
     annee_entree: number;
     role:         string;
 }
-  export interface AlumniRegisterPayload {
+export interface AlumniRegisterPayload {
     user:             UserForm;
     date_fin_cycle:   string;
     secteur_activite: string;
@@ -52,6 +52,18 @@ export interface StudentRegisterPayload {
     nom_entreprise:   string;
     filiere:          string;
     role:             string;
+}
+
+export interface UpdateProfilePayload {
+  username?: string;
+  nom?: string;
+  prenom?: string;
+  photo_profil?: string | null;
+  biographie?: string | null;
+}
+
+export interface ChangeEmailPayload {
+  email: string;
 }
 
 


### PR DESCRIPTION
## Summary
- connect profile editing to backend API
- implement updateProfile and changeEmail API calls
- update types
- wire PersonalProfile component to use backend and show toast

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ede563208331bb1f42876c0a88e4