### PR TITLE
Add event creation form with live preview

### DIFF
--- a/web/src/app/evenement/page.tsx
+++ b/web/src/app/evenement/page.tsx
@@ -4,12 +4,14 @@ import { useEffect, useState } from "react";
 import { CalendarIcon } from "lucide-react";
 import { api } from "@/lib/api/axios";
 import { ApiEvent } from "@/types/evenement";
+import AddEventForm from "@/components/AddEventForm";
 
 export default function Page() {
   const [events, setEvents] = useState<ApiEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
 
   useEffect(() => {
     async function fetchEvents() {
@@ -39,6 +41,11 @@ export default function Page() {
     fetchEvents();
   }, []);
 
+  const handleCreated = (ev: ApiEvent) => {
+    setEvents((prev) => [...prev, ev]);
+    setShowForm(false);
+  };
+
   if (loading) {
     return (
       <div className="flex justify-center mt-10">
@@ -55,16 +62,20 @@ export default function Page() {
     );
   }
 
-  if (events.length === 0) {
-    return (
-      <div className="alert alert-info max-w-lg mx-auto mt-10">
-        <span>Aucun événement futur pour le moment.</span>
-      </div>
-    );
-  }
-
   return (
-    <main className="p-4 lg:p-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <main className="p-4 lg:p-8">
+      <div className="mb-4">
+        <button className="btn btn-secondary" onClick={() => setShowForm((s) => !s)}>
+          + ajouter un évènement
+        </button>
+      </div>
+      {showForm && <AddEventForm onCreated={handleCreated} />}
+      {events.length === 0 && (
+        <div className="alert alert-info max-w-lg mx-auto mt-10">
+          <span>Aucun événement futur pour le moment.</span>
+        </div>
+      )}
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {events.map((ev) => (
         <div
           key={ev.titre}
@@ -105,6 +116,7 @@ export default function Page() {
           </div>
         </div>
       ))}
+      </div>
     </main>
   );
 }

--- a/web/src/components/AddEventForm.tsx
+++ b/web/src/components/AddEventForm.tsx
@@ -1,0 +1,90 @@
+"use client";
+import { useState } from "react";
+import { api } from "@/lib/api/axios";
+import EventCard from "./EventCard";
+import { Input } from "@/components/ui/Input";
+
+export interface AddEventFormProps {
+  onCreated?: (event: any) => void;
+}
+
+export default function AddEventForm({ onCreated }: AddEventFormProps) {
+  const [form, setForm] = useState({
+    titre: "",
+    description: "",
+    date_debut: "",
+    date_fin: "",
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await api.post("/events/creer/", form);
+      if (res.status >= 200 && res.status < 300) {
+        onCreated?.(res.data);
+        setForm({ titre: "", description: "", date_debut: "", date_fin: "" });
+      } else {
+        setError("Erreur lors de la création.");
+      }
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mb-6 space-y-4">
+      {error && <div className="alert alert-error">{error}</div>}
+      <Input
+        label="Titre"
+        name="titre"
+        value={form.titre}
+        onChange={handleChange}
+        required
+      />
+      <label className="block">
+        <span>Description</span>
+        <textarea
+          name="description"
+          className="textarea textarea-bordered w-full"
+          value={form.description}
+          onChange={handleChange}
+          required
+        />
+      </label>
+      <Input
+        label="Date début"
+        type="datetime-local"
+        name="date_debut"
+        value={form.date_debut}
+        onChange={handleChange}
+        required
+      />
+      <Input
+        label="Date fin"
+        type="datetime-local"
+        name="date_fin"
+        value={form.date_fin}
+        onChange={handleChange}
+        required
+      />
+      <button className="btn btn-primary" disabled={submitting} type="submit">
+        Créer l'évènement
+      </button>
+      <div className="mt-6">
+        <span className="font-bold mb-2 block">Prévisualisation :</span>
+        <EventCard event={{ ...form }} />
+      </div>
+    </form>
+  );
+}

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -1,0 +1,47 @@
+import { CalendarIcon } from "lucide-react";
+
+export interface EventCardProps {
+  event: {
+    titre: string;
+    description: string;
+    date_debut: string;
+    date_fin?: string;
+    image?: string;
+  };
+  expanded?: boolean;
+  onToggle?(): void;
+}
+
+export default function EventCard({ event, expanded, onToggle }: EventCardProps) {
+  return (
+    <div
+      className={`card card-lg w-96 bg-base-100 ${event.image ? "" : "card-xl"} shadow-sm`}
+      onClick={onToggle}
+    >
+      {event.image && (
+        <figure>
+          <img src={event.image} alt={event.titre} className="h-48 w-full object-cover" />
+        </figure>
+      )}
+      <div className="card-body">
+        <h2 className="card-title">{event.titre || ""}</h2>
+        <p className={`text-sm opacity-80 cursor-pointer ${expanded ? "" : "line-clamp-3"}`}>
+          {event.description || ""}
+        </p>
+        {event.date_debut && (
+          <div className="flex items-center gap-2 mt-2 text-sm">
+            <CalendarIcon size={18} />
+            {new Date(event.date_debut).toLocaleString(undefined, {
+              weekday: "short",
+              day: "numeric",
+              month: "short",
+              year: "numeric",
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `EventCard` component
- add `AddEventForm` for creating events
- update event page to allow creating events and previewing new card

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684896af53848331b1011670e630308f