### PR TITLE
Add editable biography and photo in profile

### DIFF
--- a/web/src/lib/api/auth.tsx
+++ b/web/src/lib/api/auth.tsx
@@ -27,14 +27,19 @@ export async function registerAlumni(data: AlumniRegisterPayload) {
   return res;
 }
 
-export async function updateProfile(data: Partial<{
-  username: string;
-  nom: string;
-  prenom: string;
-  photo_profil: string | null;
-  biographie: string | null;
-}>) {
-  const res = await api.put("/accounts/me/update/", data);
+export async function updateProfile(
+  data: Record<string, string | File | null | undefined>
+) {
+  const formData = new FormData();
+  Object.entries(data).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      formData.append(key, value);
+    }
+  });
+
+  const res = await api.put("/accounts/me/update/", formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
   return res.data;
 }
 


### PR DESCRIPTION
## Summary
- allow backend photo uploads from profile component
- show uploaded photo or fallback initials in profile
- edit and save biography text

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npx tsc --noEmit` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68494f360f688331b4c1ee80cf68d8f8