### PR TITLE
Fix signup Bad Request

### DIFF
--- a/web/src/app/auth/signIn/page.tsx
+++ b/web/src/app/auth/signIn/page.tsx
@@ -39,7 +39,13 @@ export default function SignIn() {
 
   useEffect(() => {
     fetchFilieres()
-      .then((data) => setFilieres(data))
+      .then((data) => {
+        setFilieres(data);
+        if (data.length > 0) {
+          setAlumniData((prev) => ({ ...prev, filiere: data[0].code }));
+          setStudentData((prev) => ({ ...prev, filiere: data[0].code }));
+        }
+      })
       .catch((err) => console.error(err));
   }, []);
 
@@ -154,7 +160,11 @@ export default function SignIn() {
 
   const handleAlumniChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
-  ) => setAlumniData((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  ) =>
+    setAlumniData((prev) => ({
+      ...prev,
+      [e.target.name]: e.target.value,
+    }));
 
   // Combinaison : met à jour alumniData + l'état « en recherche d'emploi »
   const handleSituationChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -164,7 +174,11 @@ export default function SignIn() {
 
   const handleStudentChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
-  ) => setStudentData((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  ) =>
+    setStudentData((prev) => ({
+      ...prev,
+      [e.target.name]: e.target.value,
+    }));
 
   /** Soumission du formulaire */
   const handleSubmit = async (e: React.FormEvent) => {
@@ -399,12 +413,10 @@ export default function SignIn() {
                     value={alumniData.situation_pro}
                     onChange={handleSituationChange}
                   >
-                    <option value="En recherche d'emploi">
-                      En recherche d'emploi
-                    </option>
+                    <option value="chomage">En recherche d'emploi</option>
                     <option value="stage">En stage</option>
-                    <option value="employee">En emploi</option>
-                    <option value="Entrepreneur">En formation</option>
+                    <option value="emploi">En emploi</option>
+                    <option value="formation">En formation</option>
                     <option value="autre">Autre</option>
                   </select>
                 </div>


### PR DESCRIPTION
## Summary
- send Filiere code to backend during signup
- type StudentRegisterPayload and AlumniRegisterPayload to use string code
- default signup forms to first filiere code
- fix situation options to match backend values

## Testing
- `npm run lint` *(fails: next not found)*
- `python manage.py check` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a900fbafc8331aefe1c62b2d2d668