### PR TITLE
Move add event button and filter user events

### DIFF
--- a/web/src/app/evenement/page.tsx
+++ b/web/src/app/evenement/page.tsx
@@ -12,6 +12,7 @@ export default function Page() {
   const [error, setError] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const [showForm, setShowForm] = useState(false);
+  const [showMyEvents, setShowMyEvents] = useState(false);
 
   useEffect(() => {
     async function fetchEvents() {
@@ -67,19 +68,19 @@ export default function Page() {
       <div className="mb-4">
         <button
           className="btn btn-secondary"
-          onClick={() => setShowForm((s) => !s)}
+          onClick={() => setShowMyEvents((s) => !s)}
         >
-          +
+          Mes évènements
         </button>
       </div>
       {showForm && <AddEventForm onCreated={handleCreated} />}
-      {events.length === 0 && (
+      {(showMyEvents ? events.filter((e) => e.is_owner).length === 0 : events.length === 0) && (
         <div className="alert alert-info max-w-lg mx-auto mt-10">
           <span>Aucun événement futur pour le moment.</span>
         </div>
       )}
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {events.map((ev) => (
+        {(showMyEvents ? events.filter((e) => e.is_owner) : events).map((ev) => (
           <div
             key={ev.id}
             className={`card card-lg w-96 bg-base-100 ${ev.image ? "" : "card-xl"} shadow-sm`}
@@ -118,6 +119,13 @@ export default function Page() {
           </div>
         ))}
       </div>
+      <button
+        className="btn btn-secondary fixed bottom-4 left-4 w-12 h-12 rounded-full flex items-center justify-center"
+        onClick={() => setShowForm((s) => !s)}
+      >
+        +
+      </button>
     </main>
   );
 }
+

--- a/web/src/types/evenement.d.ts
+++ b/web/src/types/evenement.d.ts
@@ -6,7 +6,9 @@ export interface ApiEvent {
     date_debut_affiche: string;     // "14-06-2025 à 09h:00"
     date_fin_affiche?: string;
     date_debut: string; // ISO string
-    date_fin?: string; 
+    date_fin?: string;
     image?: string;
+    /** indique si l'utilisateur connecté est le créateur */
+    is_owner?: boolean;
   }
   


### PR DESCRIPTION
## Summary
- place the add event button in the bottom left
- add "Mes évènements" button to filter only owned events
- include `is_owner` in the `ApiEvent` type

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ebd9ddcb0833197f5e65065cca669