### PR TITLE
Center profile overlay within main area

### DIFF
--- a/web/src/components/ui/personal-profile.tsx
+++ b/web/src/components/ui/personal-profile.tsx
@@ -65,7 +65,7 @@ export default function PersonalProfile({ onClose }: PersonalProfileProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/40"
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
       <motion.div

--- a/web/src/components/ui/side-panel.tsx
+++ b/web/src/components/ui/side-panel.tsx
@@ -147,9 +147,10 @@ export default function SidePanel({ children }: { children: ReactNode }) {
           </button>
         </div>
       </aside>
-      {showProfile && <PersonalProfile onClose={handleCloseProfile} />}
-
-      <main className="flex-1 overflow-auto">{children}</main>
+      <main className="relative flex-1 overflow-auto">
+        {showProfile && <PersonalProfile onClose={handleCloseProfile} />}
+        {children}
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- ensure PersonalProfile is rendered inside the `<main>` container
- make PersonalProfile overlay absolute relative to main

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed1b0eaf88331866ed08ca4b8d675