### PR TITLE
Use modal for event details

### DIFF
--- a/web/src/app/evenement/page.tsx
+++ b/web/src/app/evenement/page.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { CalendarIcon } from "lucide-react";
 import { api } from "@/lib/api/axios";
 import { ApiEvent } from "@/types/evenement";
 import AddEventForm from "@/components/AddEventForm";
+import EventCard from "@/components/EventCard";
+import EventModal from "@/components/EventModal";
 
 export default function Page() {
   const [events, setEvents] = useState<ApiEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [selectedEvent, setSelectedEvent] = useState<ApiEvent | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [showMyEvents, setShowMyEvents] = useState(false);
 
@@ -81,44 +82,12 @@ export default function Page() {
       )}
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {(showMyEvents ? events.filter((e) => e.is_owner) : events).map((ev) => (
-          <div
-            key={ev.id}
-            className={`card card-lg w-96 bg-base-100 ${ev.image ? "" : "card-xl"} shadow-sm`}
-            onClick={() => setExpandedId(expandedId === ev.id ? null : ev.id)}
-          >
-            {ev.image && (
-              <figure>
-                <img
-                  src={ev.image}
-                  alt={ev.titre}
-                  className="h-48 w-full object-cover"
-                />
-              </figure>
-            )}
-            <div className="card-body">
-              <h2 className="card-title">{ev.titre}</h2>
-              <p
-                className={`text-sm opacity-80 cursor-pointer ${
-                  expandedId === ev.id ? "" : "line-clamp-3"
-                }`}
-              >
-                {ev.description}
-              </p>
-              <div className="flex items-center gap-2 mt-2 text-sm">
-                <CalendarIcon size={18} />
-                {new Date(ev.date_debut).toLocaleString(undefined, {
-                  weekday: "short",
-                  day: "numeric",
-                  month: "short",
-                  year: "numeric",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}
-              </div>
-            </div>
-          </div>
+          <EventCard key={ev.id} event={ev} onToggle={() => setSelectedEvent(ev)} />
         ))}
       </div>
+      {selectedEvent && (
+        <EventModal event={selectedEvent} onClose={() => setSelectedEvent(null)} />
+      )}
       <button
         className="btn btn-secondary fixed bottom-4 left-4 w-12 h-12 rounded-full flex items-center justify-center"
         onClick={() => setShowForm((s) => !s)}

--- a/web/src/components/EventModal.tsx
+++ b/web/src/components/EventModal.tsx
@@ -1,0 +1,61 @@
+import { CalendarIcon, XIcon } from "lucide-react";
+import { motion } from "framer-motion";
+import { useEffect } from "react";
+import { ApiEvent } from "@/types/evenement";
+
+interface EventModalProps {
+  event: ApiEvent;
+  onClose(): void;
+}
+
+export default function EventModal({ event, onClose }: EventModalProps) {
+  useEffect(() => {
+    const esc = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [onClose]);
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.25 }}
+        className="relative w-full max-w-2xl bg-base-100 rounded-lg p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          className="btn btn-sm btn-circle absolute top-2 right-2"
+          onClick={onClose}
+        >
+          <XIcon size={18} />
+        </button>
+        {event.image && (
+          <img
+            src={event.image}
+            alt={event.titre}
+            className="w-full h-64 object-cover rounded-md mb-4"
+          />
+        )}
+        <h2 className="text-2xl font-bold mb-2">{event.titre}</h2>
+        <p className="mb-4 whitespace-pre-line text-sm opacity-80">
+          {event.description}
+        </p>
+        <div className="flex items-center gap-2 text-sm">
+          <CalendarIcon size={18} />
+          {new Date(event.date_debut).toLocaleString(undefined, {
+            weekday: "short",
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+          })}
+        </div>
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- open event details in a modal overlay
- show modal when clicking on an event

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed5d988a483319bc4c7ed142c1e71