### PR TITLE
Add event editing and deletion controls

### DIFF
--- a/web/src/app/evenement/page.tsx
+++ b/web/src/app/evenement/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { api } from "@/lib/api/axios";
 import { ApiEvent } from "@/types/evenement";
 import AddEventModal from "@/components/AddEventModal";
+import EditEventModal from "@/components/EditEventModal";
 import EventCard from "@/components/EventCard";
 import EventModal from "@/components/EventModal";
 
@@ -14,6 +15,7 @@ export default function Page() {
   const [selectedEvent, setSelectedEvent] = useState<ApiEvent | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [showMyEvents, setShowMyEvents] = useState(false);
+  const [editingEvent, setEditingEvent] = useState<ApiEvent | null>(null);
 
   useEffect(() => {
     async function fetchEvents() {
@@ -48,6 +50,23 @@ export default function Page() {
     setShowForm(false);
   };
 
+  const handleUpdated = (ev: ApiEvent) => {
+    setEvents((prev) => prev.map((e) => (e.id === ev.id ? ev : e)));
+    setEditingEvent(null);
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm("Supprimer cet événement ?")) return;
+    try {
+      const res = await api.delete(`/events/evenements/${id}/supprimer/`);
+      if (res.status >= 200 && res.status < 300) {
+        setEvents((prev) => prev.filter((e) => e.id !== id));
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   if (loading) {
     return (
       <div className="flex justify-center mt-10">
@@ -77,6 +96,13 @@ export default function Page() {
       {showForm && (
         <AddEventModal onCreated={handleCreated} onClose={() => setShowForm(false)} />
       )}
+      {editingEvent && (
+        <EditEventModal
+          event={editingEvent}
+          onUpdated={handleUpdated}
+          onClose={() => setEditingEvent(null)}
+        />
+      )}
       {(showMyEvents
         ? events.filter((e) => e.is_owner).length === 0
         : events.length === 0) && (
@@ -85,15 +111,16 @@ export default function Page() {
         </div>
       )}
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {(showMyEvents ? events.filter((e) => e.is_owner) : events).map(
-          (ev) => (
-            <EventCard
-              key={ev.id}
-              event={ev}
-              onToggle={() => setSelectedEvent(ev)}
-            />
-          )
-        )}
+        {(showMyEvents ? events.filter((e) => e.is_owner) : events).map((ev) => (
+          <EventCard
+            key={ev.id}
+            event={ev}
+            onToggle={() => setSelectedEvent(ev)}
+            showActions={showMyEvents}
+            onEdit={() => setEditingEvent(ev)}
+            onDelete={() => handleDelete(ev.id)}
+          />
+        ))}
       </div>
       {selectedEvent && (
         <EventModal

--- a/web/src/components/EditEventModal.tsx
+++ b/web/src/components/EditEventModal.tsx
@@ -1,0 +1,126 @@
+"use client";
+import { CalendarIcon, XIcon } from "lucide-react";
+import { motion } from "framer-motion";
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api/axios";
+import { ApiEvent } from "@/types/evenement";
+
+interface EditEventModalProps {
+  event: ApiEvent;
+  onClose(): void;
+  onUpdated?: (event: ApiEvent) => void;
+}
+
+export default function EditEventModal({ event, onClose, onUpdated }: EditEventModalProps) {
+  const [form, setForm] = useState({
+    titre: event.titre,
+    description: event.description,
+    date_debut: event.date_debut,
+    date_fin: event.date_fin,
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await api.put<ApiEvent>(
+        `/events/evenements/${event.id}/modifier/`,
+        form
+      );
+      if (res.status >= 200 && res.status < 300) {
+        onUpdated?.(res.data);
+        onClose();
+      } else {
+        setError("Erreur lors de la modification.");
+      }
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  useEffect(() => {
+    const esc = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [onClose]);
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <motion.form
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.25 }}
+        className="relative w-full max-w-2xl bg-base-100 rounded-lg p-6 shadow-xl space-y-4"
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={handleSubmit}
+      >
+        <button
+          className="btn btn-sm btn-circle absolute top-2 right-2"
+          type="button"
+          onClick={onClose}
+        >
+          <XIcon size={18} />
+        </button>
+        {error && <div className="alert alert-error">{error}</div>}
+        <input
+          name="titre"
+          value={form.titre}
+          onChange={handleChange}
+          placeholder="Titre"
+          required
+          className="input input-ghost text-2xl font-bold w-full"
+        />
+        <textarea
+          name="description"
+          value={form.description}
+          onChange={handleChange}
+          placeholder="Description"
+          required
+          className="textarea textarea-ghost w-full text-sm opacity-80 h-32"
+        />
+        <div className="flex justify-between items-center text-sm gap-4 flex-wrap">
+          <div className="flex items-center gap-2 flex-1 min-w-[10rem]">
+            <CalendarIcon size={18} />
+            <input
+              type="datetime-local"
+              name="date_debut"
+              value={form.date_debut}
+              onChange={handleChange}
+              required
+              className="input input-ghost w-full"
+            />
+          </div>
+          <div className="flex items-center gap-2 flex-1 min-w-[10rem]">
+            <CalendarIcon size={18} />
+            <input
+              type="datetime-local"
+              name="date_fin"
+              value={form.date_fin}
+              onChange={handleChange}
+              required
+              className="input input-ghost w-full"
+            />
+          </div>
+        </div>
+        <button className="btn btn-primary" disabled={submitting} type="submit">
+          Modifier l'évènement
+        </button>
+      </motion.form>
+    </div>
+  );
+}

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -1,4 +1,4 @@
-import { CalendarIcon } from "lucide-react";
+import { CalendarIcon, Edit2 as Pencil, Trash } from "lucide-react";
 
 export interface EventCardProps {
   event: {
@@ -10,14 +10,46 @@ export interface EventCardProps {
   };
   expanded?: boolean;
   onToggle?(): void;
+  showActions?: boolean;
+  onEdit?(): void;
+  onDelete?(): void;
 }
 
-export default function EventCard({ event, expanded, onToggle }: EventCardProps) {
+export default function EventCard({
+  event,
+  expanded,
+  onToggle,
+  showActions,
+  onEdit,
+  onDelete,
+}: EventCardProps) {
   return (
     <div
-      className={`card card-lg w-96 bg-base-100 ${event.image ? "" : "card-xl"} shadow-sm`}
+      className={`relative card card-lg w-96 bg-base-100 ${event.image ? "" : "card-xl"} shadow-sm`}
       onClick={onToggle}
     >
+      {showActions && (
+        <>
+          <button
+            className="btn btn-xs btn-circle absolute top-2 left-2 z-10"
+            onClick={(e) => {
+              e.stopPropagation();
+              onEdit?.();
+            }}
+          >
+            <Pencil size={12} />
+          </button>
+          <button
+            className="btn btn-xs btn-circle btn-error absolute top-2 right-2 z-10"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete?.();
+            }}
+          >
+            <Trash size={12} />
+          </button>
+        </>
+      )}
       {event.image && (
         <figure>
           <img src={event.image} alt={event.titre} className="h-48 w-full object-cover" />


### PR DESCRIPTION
## Summary
- show edit & delete buttons on event cards when viewing my events
- implement modal to modify events
- support deleting events

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685049a59a808331ae32e50be757223d