### PR TITLE
Add members page with search

### DIFF
--- a/web/src/app/usersList/page.tsx
+++ b/web/src/app/usersList/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useEffect, useState } from "react";
+import UserCard from "@/components/UserCard";
+import { Input } from "@/components/ui/Input";
+import { api } from "@/lib/api/axios";
+import { User } from "@/types/auth";
+
+export default function UsersListPage() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const fetchUsers = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+          const res = await api.get<User[]>("/accounts/rechercher-utilisateur/", {
+            params: search ? { search } : {},
+          });
+          setUsers(res.data);
+        } catch (err: any) {
+          setError(err.message);
+        } finally {
+          setLoading(false);
+        }
+      };
+      fetchUsers();
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  return (
+    <main className="p-4 space-y-4">
+      <div className="max-w-md">
+        <Input
+          placeholder="Rechercher..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+      </div>
+      {loading && (
+        <div className="flex justify-center">
+          <span className="loading loading-spinner" />
+        </div>
+      )}
+      {error && <div className="alert alert-error">{error}</div>}
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        {users.map((u) => (
+          <UserCard key={u.id} user={u} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/web/src/components/UserCard.tsx
+++ b/web/src/components/UserCard.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { User } from "@/types/auth";
+
+interface UserCardProps {
+  user: User;
+}
+
+export default function UserCard({ user }: UserCardProps) {
+  return (
+    <div className="card bg-base-100 shadow-sm">
+      <div className="card-body flex items-center gap-4">
+        <div className="avatar">
+          <div className="w-12 rounded-full bg-base-200 overflow-hidden">
+            {user.photo_profil ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={user.photo_profil} alt={user.username} />
+            ) : (
+              <span className="flex items-center justify-center w-full h-full font-semibold">
+                {user.username.charAt(0).toUpperCase()}
+              </span>
+            )}
+          </div>
+        </div>
+        <div>
+          <h2 className="font-semibold">
+            {user.prenom} {user.nom}
+          </h2>
+          <p className="text-sm opacity-70">
+            @{user.username} - {user.role}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement a user list page at `/usersList`
- add a reusable `UserCard` component for displaying users

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516250bd88833184ed2f4fc09d1a24