### PR TITLE
Add real-time messaging UI and WebSocket backend

### DIFF
--- a/backend/backend2/asgi.py
+++ b/backend/backend2/asgi.py
@@ -12,6 +12,7 @@ from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.auth import AuthMiddlewareStack
 from django.core.asgi import get_asgi_application
 import notifications.routing
+import messaging.routing
 
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend2.settings')
@@ -21,6 +22,7 @@ application = ProtocolTypeRouter({
     "websocket": AuthMiddlewareStack(
         URLRouter(
             notifications.routing.websocket_urlpatterns
+            + messaging.routing.websocket_urlpatterns
         )
     ),
 })

--- a/backend/messaging/consumers.py
+++ b/backend/messaging/consumers.py
@@ -1,0 +1,60 @@
+import json
+from channels.generic.websocket import AsyncWebsocketConsumer
+from channels.db import database_sync_to_async
+from django.contrib.auth import get_user_model
+from .models import MessagePrive
+from .serializers import MessagePriveSerializer
+
+User = get_user_model()
+
+class ChatConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        user = self.scope["user"]
+        other_id = self.scope["url_route"]["kwargs"].get("user_id")
+        if not user.is_authenticated or other_id is None:
+            await self.close()
+            return
+        self.other_user = await self.get_user(other_id)
+        if not self.other_user:
+            await self.close()
+            return
+        ids = sorted([user.id, self.other_user.id])
+        self.group_name = f"chat_{ids[0]}_{ids[1]}"
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, close_code):
+        if hasattr(self, "group_name"):
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+
+    async def receive(self, text_data=None, bytes_data=None):
+        if text_data is None:
+            return
+        data = json.loads(text_data)
+        content = data.get("message")
+        if not content:
+            return
+        message = await self.create_message(self.scope["user"], self.other_user, content)
+        serialized = await self.serialize_message(message)
+        await self.channel_layer.group_send(
+            self.group_name,
+            {"type": "chat_message", "message": serialized},
+        )
+
+    async def chat_message(self, event):
+        await self.send(text_data=json.dumps(event["message"]))
+
+    @database_sync_to_async
+    def get_user(self, user_id):
+        try:
+            return User.objects.get(id=user_id)
+        except User.DoesNotExist:
+            return None
+
+    @database_sync_to_async
+    def create_message(self, sender, recipient, content):
+        return MessagePrive.objects.create(expediteur=sender, destinataire=recipient, contenu=content)
+
+    @database_sync_to_async
+    def serialize_message(self, message):
+        return MessagePriveSerializer(message).data

--- a/backend/messaging/routing.py
+++ b/backend/messaging/routing.py
@@ -1,0 +1,6 @@
+from django.urls import re_path
+from . import consumers
+
+websocket_urlpatterns = [
+    re_path(r"ws/chat/(?P<user_id>\d+)/$", consumers.ChatConsumer.as_asgi()),
+]

--- a/backend/messaging/urls.py
+++ b/backend/messaging/urls.py
@@ -1,8 +1,16 @@
 from django.urls import path
-from .views import EnvoyerMessagePriveView, MessagesRecusView, MessagesEnvoyesView
+from .views import (
+    EnvoyerMessagePriveView,
+    MessagesRecusView,
+    MessagesEnvoyesView,
+    ConversationsListView,
+    MessagesWithUserView,
+)
 
 urlpatterns = [
     path('envoyer/', EnvoyerMessagePriveView.as_view(), name='envoyer_message'),
     path('recus/', MessagesRecusView.as_view(), name='messages_recus'),
     path('envoyes/', MessagesEnvoyesView.as_view(), name='messages_envoyes'),
+    path('conversations/', ConversationsListView.as_view(), name='conversations'),
+    path('with/<str:username>/', MessagesWithUserView.as_view(), name='messages_with_user'),
 ]

--- a/backend/messaging/views.py
+++ b/backend/messaging/views.py
@@ -1,6 +1,8 @@
 from rest_framework import generics, status, serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
+from django.db.models import Q
 from .models import MessagePrive
 from .serializers import MessagePriveSerializer
 from accounts.models import CustomUser
@@ -80,3 +82,67 @@ class MessagesEnvoyesView(generics.ListAPIView):
 
     def get_queryset(self):
         return MessagePrive.objects.filter(expediteur=self.request.user).order_by('-date_envoi')
+
+
+# === Lister les conversations ===
+class ConversationsListView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        user = request.user
+        messages = (
+            MessagePrive.objects
+            .filter(Q(expediteur=user) | Q(destinataire=user))
+            .select_related('expediteur', 'destinataire')
+            .order_by('-date_envoi')
+        )
+
+        convo_map = {}
+        for msg in messages:
+            other = msg.destinataire if msg.expediteur == user else msg.expediteur
+            if other.id not in convo_map:
+                convo_map[other.id] = msg
+
+        data = []
+        for other_id, last_msg in convo_map.items():
+            other = last_msg.destinataire if last_msg.expediteur == user else last_msg.expediteur
+            data.append({
+                'id': other.id,
+                'username': other.username,
+                'prenom': other.prenom,
+                'nom': other.nom,
+                'photo_profil': other.photo_profil.url if other.photo_profil else None,
+                'last_message': MessagePriveSerializer(last_msg).data,
+            })
+
+        return Response(data)
+
+
+# === Voir les messages d'une conversation ===
+class MessagesWithUserView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, username):
+        try:
+            other = CustomUser.objects.get(username=username)
+        except CustomUser.DoesNotExist:
+            return Response({'detail': 'Utilisateur introuvable.'}, status=status.HTTP_404_NOT_FOUND)
+
+        messages = (
+            MessagePrive.objects
+            .filter(
+                Q(expediteur=request.user, destinataire=other) |
+                Q(expediteur=other, destinataire=request.user)
+            )
+            .order_by('date_envoi')
+        )
+
+        serialized = MessagePriveSerializer(messages, many=True).data
+        user_data = {
+            'id': other.id,
+            'username': other.username,
+            'prenom': other.prenom,
+            'nom': other.nom,
+            'photo_profil': other.photo_profil.url if other.photo_profil else None,
+        }
+        return Response({'user': user_data, 'messages': serialized})

--- a/web/src/app/discussions/[username]/page.tsx
+++ b/web/src/app/discussions/[username]/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+import { useEffect, useState, useRef } from "react";
+import { useParams } from "next/navigation";
+import { fetchConversation } from "@/lib/api/messaging";
+import { ConversationDetail, Message } from "@/types/messaging";
+import { Input } from "@/components/ui/Input";
+
+export default function ConversationPage() {
+  const { username } = useParams<{ username: string }>();
+  const [conversation, setConversation] = useState<ConversationDetail | null>(null);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [content, setContent] = useState("");
+  const wsRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    if (!username) return;
+    fetchConversation(username).then((data) => {
+      setConversation(data);
+      setMessages(data.messages);
+      openSocket(data.user.id);
+    });
+    return () => {
+      wsRef.current?.close();
+    };
+  }, [username]);
+
+  function openSocket(userId: number) {
+    const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+    const ws = new WebSocket(`${protocol}://${window.location.host}/ws/chat/${userId}/`);
+    wsRef.current = ws;
+    ws.onmessage = (event) => {
+      const msg: Message = JSON.parse(event.data);
+      setMessages((prev) => [...prev, msg]);
+    };
+  }
+
+  function sendMessage() {
+    if (!wsRef.current || !content.trim()) return;
+    wsRef.current.send(JSON.stringify({ message: content }));
+    setContent("");
+  }
+
+  if (!conversation) {
+    return (
+      <div className="flex justify-center p-4">
+        <span className="loading loading-spinner" />
+      </div>
+    );
+  }
+
+  return (
+    <main className="flex flex-col h-screen p-4">
+      <h2 className="text-xl font-semibold mb-4">
+        Conversation avec {conversation.user.prenom} {conversation.user.nom}
+      </h2>
+      <div className="flex-1 overflow-y-auto space-y-2">
+        {messages.map((m) => (
+          <div
+            key={m.id}
+            className={`chat ${m.expediteur_username === conversation.user.username ? "chat-start" : "chat-end"}`}
+          >
+            <div className="chat-bubble">{m.contenu}</div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-2 flex gap-2">
+        <Input
+          className="flex-1"
+          placeholder="Votre message"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <button className="btn btn-primary" onClick={sendMessage}>
+          Envoyer
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/discussions/page.tsx
+++ b/web/src/app/discussions/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { fetchConversations } from "@/lib/api/messaging";
+import { Conversation } from "@/types/messaging";
+
+export default function DiscussionsPage() {
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchConversations()
+      .then(setConversations)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-4">
+        <span className="loading loading-spinner" />
+      </div>
+    );
+  }
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Discussions</h1>
+      <ul className="space-y-2">
+        {conversations.map((conv) => (
+          <li key={conv.id}>
+            <Link
+              href={`/discussions/${conv.username}`}
+              className="flex items-center gap-3 p-3 bg-base-200 rounded-md hover:bg-base-300"
+            >
+              <div className="avatar">
+                <div className="w-10 rounded-full bg-base-300 overflow-hidden">
+                  {conv.photo_profil ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={conv.photo_profil} alt={conv.username} />
+                  ) : (
+                    <span className="flex items-center justify-center h-full font-semibold">
+                      {conv.username.charAt(0).toUpperCase()}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div>
+                <p className="font-semibold">
+                  {conv.prenom} {conv.nom}
+                </p>
+                <p className="text-sm opacity-70 truncate max-w-xs">
+                  {conv.last_message.contenu}
+                </p>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/web/src/lib/api/messaging.ts
+++ b/web/src/lib/api/messaging.ts
@@ -1,0 +1,12 @@
+import { api } from "./axios";
+import { Conversation, ConversationDetail, Message } from "@/types/messaging";
+
+export async function fetchConversations() {
+  const res = await api.get<Conversation[]>("/messaging/conversations/");
+  return res.data;
+}
+
+export async function fetchConversation(username: string) {
+  const res = await api.get<ConversationDetail>(`/messaging/with/${username}/`);
+  return res.data;
+}

--- a/web/src/types/messaging.d.ts
+++ b/web/src/types/messaging.d.ts
@@ -1,0 +1,29 @@
+export interface Message {
+  id: number;
+  expediteur: number;
+  destinataire: number;
+  contenu: string;
+  date_envoi: string;
+  expediteur_username: string;
+  destinataire_username: string;
+}
+
+export interface Conversation {
+  id: number;
+  username: string;
+  prenom: string;
+  nom: string;
+  photo_profil: string | null;
+  last_message: Message;
+}
+
+export interface ConversationDetail {
+  user: {
+    id: number;
+    username: string;
+    prenom: string;
+    nom: string;
+    photo_profil: string | null;
+  };
+  messages: Message[];
+}


### PR DESCRIPTION
## Summary
- expose chat websocket routing in ASGI
- implement WebSocket `ChatConsumer`
- add conversation and thread API endpoints
- create Next.js pages to show conversations and chat
- add messaging API utilities and types

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516a5d82e08331a72b61ca1d818a1a