### PR TITLE
Fix messaging endpoint

### DIFF
--- a/backend/messaging/serializers.py
+++ b/backend/messaging/serializers.py
@@ -8,4 +8,4 @@ class MessagePriveSerializer(serializers.ModelSerializer):
     class Meta:
         model = MessagePrive
         fields = '__all__'
-        read_only_fields = ['expediteur', 'date_envoi']
+        read_only_fields = ['expediteur', 'destinataire', 'date_envoi']

--- a/backend/messaging/views.py
+++ b/backend/messaging/views.py
@@ -37,9 +37,15 @@ class EnvoyerMessagePriveView(generics.CreateAPIView):
         return super().post(request, *args, **kwargs)
 
     def perform_create(self, serializer):
-        destinataire_username = self.request.data.get('destinataire_username')
+        raw_dest = self.request.data.get('destinataire_username') or self.request.data.get('destinataire')
+        if not raw_dest:
+            raise serializers.ValidationError("Destinataire introuvable.")
+
         try:
-            destinataire = CustomUser.objects.get(username=destinataire_username)
+            if str(raw_dest).isdigit():
+                destinataire = CustomUser.objects.get(id=int(raw_dest))
+            else:
+                destinataire = CustomUser.objects.get(username=raw_dest)
         except CustomUser.DoesNotExist:
             raise serializers.ValidationError("Destinataire introuvable.")
 


### PR DESCRIPTION
## Summary
- allow `MessagePriveSerializer` to ignore `destinataire` field when sending a message
- robustly resolve destinatary either by username or id in `EnvoyerMessagePriveView`

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6853ae06c2388331bcf9df00df410b03