### PR TITLE
Fix messaging serializer

### DIFF
--- a/backend/messaging/serializers.py
+++ b/backend/messaging/serializers.py
@@ -8,7 +8,6 @@ class MessagePriveSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = MessagePrive
-<<<<<<< HEAD
         fields = [
             'id',
             'expediteur',
@@ -18,10 +17,7 @@ class MessagePriveSerializer(serializers.ModelSerializer):
             'contenu',
             'date_envoi'
         ]
-        read_only_fields = ['expediteur', 'date_envoi', 'destinataire']
-        extra_kwargs = {
-            'destinataire': {'read_only': True},
-        }
+        read_only_fields = ['expediteur', 'destinataire', 'date_envoi']
 
     def create(self, validated_data):
         destinataire_username = validated_data.pop('destinataire_username')
@@ -35,7 +31,3 @@ class MessagePriveSerializer(serializers.ModelSerializer):
             destinataire=destinataire,
             **validated_data
         )
-=======
-        fields = '__all__'
-        read_only_fields = ['expediteur', 'destinataire', 'date_envoi']
->>>>>>> 2d8f4d8d0f6435e56c2187f78094138eea718139

--- a/backend/messaging/views.py
+++ b/backend/messaging/views.py
@@ -1,4 +1,4 @@
-from rest_framework import generics, status
+from rest_framework import generics, status, serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -37,9 +37,6 @@ class EnvoyerMessagePriveView(generics.CreateAPIView):
         return super().post(request, *args, **kwargs)
 
     def perform_create(self, serializer):
-<<<<<<< HEAD
-        message = serializer.save()
-=======
         raw_dest = self.request.data.get('destinataire_username') or self.request.data.get('destinataire')
         if not raw_dest:
             raise serializers.ValidationError("Destinataire introuvable.")
@@ -55,7 +52,6 @@ class EnvoyerMessagePriveView(generics.CreateAPIView):
         message = serializer.save(expediteur=self.request.user, destinataire=destinataire)
 
         # 🔔 Notification en temps réel via WebSocket
->>>>>>> 2d8f4d8d0f6435e56c2187f78094138eea718139
         envoyer_notification(
             destinataire=message.destinataire,
             message=f"Nouveau message privé de {message.expediteur.username}."


### PR DESCRIPTION
## Summary
- clean up merge conflicts in messaging backend
- support looking up private message recipients by username or id

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6853b3b41f5883318d2dc8813070545e