### PR TITLE
Fix duplicate keyword error in messaging serializer

### DIFF
--- a/backend/messaging/serializers.py
+++ b/backend/messaging/serializers.py
@@ -20,14 +20,29 @@ class MessagePriveSerializer(serializers.ModelSerializer):
         read_only_fields = ['expediteur', 'destinataire', 'date_envoi']
 
     def create(self, validated_data):
-        destinataire_username = validated_data.pop('destinataire_username')
-        try:
-            destinataire = CustomUser.objects.get(username=destinataire_username)
-        except CustomUser.DoesNotExist:
-            raise serializers.ValidationError({'destinataire_username': 'Utilisateur introuvable.'})
+        """Create a ``MessagePrive`` instance.
+
+        ``destinataire`` and ``expediteur`` may be provided explicitly when
+        calling ``serializer.save``. If they are not, ``destinataire`` is
+        resolved from ``destinataire_username`` and ``expediteur`` defaults to
+        the current request user.
+        """
+
+        destinataire = validated_data.pop('destinataire', None)
+        destinataire_username = validated_data.pop('destinataire_username', None)
+
+        if destinataire is None:
+            if not destinataire_username:
+                raise serializers.ValidationError({'destinataire_username': 'Ce champ est requis.'})
+            try:
+                destinataire = CustomUser.objects.get(username=destinataire_username)
+            except CustomUser.DoesNotExist:
+                raise serializers.ValidationError({'destinataire_username': 'Utilisateur introuvable.'})
+
+        expediteur = validated_data.pop('expediteur', self.context['request'].user)
 
         return MessagePrive.objects.create(
-            expediteur=self.context['request'].user,
+            expediteur=expediteur,
             destinataire=destinataire,
             **validated_data
         )


### PR DESCRIPTION
## Summary
- allow optional `expediteur` and `destinataire` params when creating a private message
- fallback to request user and username lookup when fields are not provided

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6853b938c638833187d96c63a928b06b