### PR TITLE
Add Django admin support for private messaging

### DIFF
--- a/backend/accounts/templates/admin/envoyer_message.html
+++ b/backend/accounts/templates/admin/envoyer_message.html
@@ -1,0 +1,18 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{{ title }}</h1>
+<p>{% trans "Envoyer un message privé aux utilisateurs suivants:" %}</p>
+<ul>
+    {% for user in users %}
+    <li>{{ user.username }}</li>
+    {% endfor %}
+</ul>
+<form method="post">{% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" name="apply" value="{% trans 'Envoyer' %}" class="default"/>
+    <a href="../" class="button cancel-link">{% trans "Annuler" %}</a>
+</form>
+{% endblock %}
+

--- a/backend/messaging/admin.py
+++ b/backend/messaging/admin.py
@@ -1,3 +1,17 @@
 from django.contrib import admin
+from .models import MessagePrive
 
-# Register your models here.
+
+@admin.register(MessagePrive)
+class MessagePriveAdmin(admin.ModelAdmin):
+    """Admin for sending private messages."""
+
+    list_display = ["expediteur", "destinataire", "date_envoi"]
+    search_fields = ["expediteur__username", "destinataire__username", "contenu"]
+    readonly_fields = ["expediteur", "date_envoi"]
+    fields = ["destinataire", "contenu"]
+
+    def save_model(self, request, obj, form, change):
+        if not change:
+            obj.expediteur = request.user
+        super().save_model(request, obj, form, change)


### PR DESCRIPTION
## Summary
- register `MessagePrive` in Django admin
- add action on `CustomUserAdmin` to send private messages
- include message-sending form template

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6853be3893788331b68cae353919f0d7