### PR TITLE
Fix absolute URLs for uploaded media

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -89,7 +89,7 @@ class LoginSerializer(serializers.Serializer):
         return {
             'refresh': str(refresh),
             'access': str(refresh.access_token),
-            'user': UserSerializer(user).data
+            'user': UserSerializer(user, context=self.context).data
         }
 
 # === ÉTUDIANT READ SERIALIZER ===

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -60,20 +60,20 @@ class AlumniSearchView(generics.ListAPIView):
 # === AUTHENTIFICATION ===
 class LoginAPIView(APIView):
     def post(self, request):
-        serializer = LoginSerializer(data=request.data)
+        serializer = LoginSerializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
         return Response(serializer.validated_data)
 
 class MeAPIView(APIView):
     permission_classes = [IsAuthenticated]
     def get(self, request):
-        return Response(UserSerializer(request.user).data)
+        return Response(UserSerializer(request.user, context={'request': request}).data)
 
 # === PROFIL ===
 class UpdateProfileAPIView(APIView):
     permission_classes = [IsAuthenticated]
     def put(self, request):
-        serializer = UpdateUserSerializer(request.user, data=request.data, partial=True)
+        serializer = UpdateUserSerializer(request.user, data=request.data, partial=True, context={'request': request})
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data)

--- a/backend/publications/serializers.py
+++ b/backend/publications/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from accounts.serializers import AbsoluteMediaUrlField
 from .models import Publication, Commentaire
 
 class CommentaireSerializer(serializers.ModelSerializer):
@@ -11,6 +12,7 @@ class CommentaireSerializer(serializers.ModelSerializer):
 class PublicationSerializer(serializers.ModelSerializer):
     auteur_username = serializers.ReadOnlyField(source='auteur.username')
     commentaires = CommentaireSerializer(many=True, read_only=True)
+    photo = AbsoluteMediaUrlField(required=False)
 
     class Meta:
         model = Publication


### PR DESCRIPTION
## Summary
- include request context when serializing user info
- ensure login serializer returns absolute URLs
- expose photos in publications with absolute URLs

## Testing
- `pytest -q` *(no tests found)*
- `flake8` *(failed: command not found)*
- `python backend/manage.py check` *(failed: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6854040b7dd48331b0c9ab17b754676f