### PR TITLE
Add group features to web

### DIFF
--- a/web/src/app/groupes/[id]/page.tsx
+++ b/web/src/app/groupes/[id]/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { fetchGroups, fetchGroupMessages, sendGroupMessage } from "@/lib/api/group";
+import { Group, GroupMessage } from "@/types/group";
+import { Input } from "@/components/ui/Input";
+
+export default function GroupeDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const [group, setGroup] = useState<Group | null>(null);
+  const [messages, setMessages] = useState<GroupMessage[]>([]);
+  const [content, setContent] = useState("");
+
+  useEffect(() => {
+    if (!id) return;
+    fetchGroups().then((gs) => {
+      setGroup(gs.find((g) => g.id === Number(id)) || null);
+    });
+    fetchGroupMessages(Number(id)).then(setMessages);
+  }, [id]);
+
+  const handleSend = async () => {
+    if (!content.trim()) return;
+    const msg = await sendGroupMessage(Number(id), content);
+    setMessages((prev) => [...prev, msg]);
+    setContent("");
+  };
+
+  if (!group) {
+    return (
+      <div className="flex justify-center p-4">
+        <span className="loading loading-spinner" />
+      </div>
+    );
+  }
+
+  return (
+    <main className="flex flex-col h-screen p-4">
+      <h1 className="text-xl font-semibold mb-4">{group.nom_groupe}</h1>
+      <div className="flex-1 overflow-y-auto space-y-2">
+        {messages.map((m) => (
+          <div key={m.id} className="chat chat-start">
+            <div className="chat-bubble">
+              <strong>{m.auteur}:</strong> {m.contenu}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-2 flex gap-2">
+        <Input
+          className="flex-1"
+          placeholder="Votre message"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <button className="btn btn-primary" onClick={handleSend} disabled={!content.trim()}>
+          Envoyer
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/groupes/page.tsx
+++ b/web/src/app/groupes/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { fetchGroups, joinGroup, leaveGroup } from "@/lib/api/group";
+import AddGroupModal from "@/components/AddGroupModal";
+import { Group } from "@/types/group";
+
+export default function GroupesPage() {
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+
+  useEffect(() => {
+    fetchGroups()
+      .then(setGroups)
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleJoin = async (id: number) => {
+    await joinGroup(id);
+    setGroups((prev) =>
+      prev.map((g) =>
+        g.id === id ? { ...g, membres: [...g.membres, "me"] } : g
+      )
+    );
+  };
+
+  const handleLeave = async (id: number) => {
+    await leaveGroup(id);
+    setGroups((prev) =>
+      prev.map((g) =>
+        g.id === id ? { ...g, membres: g.membres.filter((m) => m !== "me") } : g
+      )
+    );
+  };
+
+  const handleCreated = (g: Group) => {
+    setGroups((prev) => [g, ...prev]);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-4">
+        <span className="loading loading-spinner" />
+      </div>
+    );
+  }
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Groupes</h1>
+      <button className="btn btn-primary" onClick={() => setShowForm(true)}>
+        Créer un groupe
+      </button>
+      <ul className="space-y-2">
+        {groups.map((g) => (
+          <li key={g.id} className="p-3 bg-base-200 rounded-md">
+            <Link href={`/groupes/${g.id}`} className="font-semibold">
+              {g.nom_groupe}
+            </Link>
+            <p className="text-sm opacity-80">{g.description}</p>
+            {g.membres.includes("me") ? (
+              <button className="btn btn-sm mt-2" onClick={() => handleLeave(g.id)}>
+                Quitter
+              </button>
+            ) : (
+              <button className="btn btn-sm mt-2" onClick={() => handleJoin(g.id)}>
+                Rejoindre
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+      {showForm && <AddGroupModal onClose={() => setShowForm(false)} onCreated={handleCreated} />}
+    </main>
+  );
+}

--- a/web/src/components/AddGroupModal.tsx
+++ b/web/src/components/AddGroupModal.tsx
@@ -1,0 +1,81 @@
+"use client";
+import { XIcon } from "lucide-react";
+import { motion } from "framer-motion";
+import { useEffect, useState } from "react";
+import { createGroup } from "@/lib/api/group";
+import { Group } from "@/types/group";
+
+interface AddGroupModalProps {
+  onClose(): void;
+  onCreated?: (group: Group) => void;
+}
+
+export default function AddGroupModal({ onClose, onCreated }: AddGroupModalProps) {
+  const [form, setForm] = useState({ nom_groupe: "", description: "" });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const group = await createGroup(form);
+      onCreated?.(group);
+      setForm({ nom_groupe: "", description: "" });
+      onClose();
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  useEffect(() => {
+    const esc = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [onClose]);
+
+  return (
+    <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+      <motion.form
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.25 }}
+        className="relative w-full max-w-lg bg-base-100 rounded-lg p-6 shadow-xl space-y-4"
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={handleSubmit}
+      >
+        <button type="button" className="btn btn-sm btn-circle absolute top-2 right-2" onClick={onClose}>
+          <XIcon size={18} />
+        </button>
+        {error && <div className="alert alert-error">{error}</div>}
+        <input
+          name="nom_groupe"
+          value={form.nom_groupe}
+          onChange={handleChange}
+          placeholder="Nom du groupe"
+          required
+          className="input input-ghost w-full"
+        />
+        <textarea
+          name="description"
+          value={form.description}
+          onChange={handleChange}
+          placeholder="Description"
+          required
+          className="textarea textarea-ghost w-full h-32"
+        />
+        <button className="btn btn-primary" disabled={submitting} type="submit">
+          Créer le groupe
+        </button>
+      </motion.form>
+    </div>
+  );
+}

--- a/web/src/lib/api/group.ts
+++ b/web/src/lib/api/group.ts
@@ -1,0 +1,30 @@
+import { api } from "./axios";
+import { Group, GroupMessage } from "@/types/group";
+
+export async function fetchGroups() {
+  const res = await api.get<Group[]>("/groups/listes/");
+  return res.data;
+}
+
+export async function createGroup(data: { nom_groupe: string; description: string }) {
+  const res = await api.post<Group>("/groups/creer/", data);
+  return res.data;
+}
+
+export async function joinGroup(id: number) {
+  await api.post(`/groups/${id}/rejoindre/`);
+}
+
+export async function leaveGroup(id: number) {
+  await api.post(`/groups/${id}/quitter/`);
+}
+
+export async function fetchGroupMessages(id: number) {
+  const res = await api.get<GroupMessage[]>(`/groups/${id}/messages/`);
+  return res.data;
+}
+
+export async function sendGroupMessage(id: number, contenu: string) {
+  const res = await api.post<GroupMessage>(`/groups/${id}/envoyer-message/`, { contenu });
+  return res.data;
+}

--- a/web/src/types/group.d.ts
+++ b/web/src/types/group.d.ts
@@ -1,0 +1,16 @@
+export interface Group {
+  id: number;
+  nom_groupe: string;
+  description: string;
+  createur: string;
+  membres: string[];
+  date_creation: string;
+}
+
+export interface GroupMessage {
+  id: number;
+  groupe: number;
+  auteur: string;
+  contenu: string;
+  date_envoi: string;
+}


### PR DESCRIPTION
## Summary
- add TypeScript types for group & group messages
- add API helpers for group endpoints
- add modal component to create groups
- implement group listing page with join/leave actions
- implement group detail page to view and send messages

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685581e608588331b9b9bc4a45cfc188