### PR TITLE
Add mentorship requests features

### DIFF
--- a/web/src/app/mentorat/page.tsx
+++ b/web/src/app/mentorat/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+import { useEffect, useState } from "react";
+import { fetchMesDemandes, repondreDemande } from "@/lib/api/mentorat";
+import { DemandeMentorat } from "@/types/mentorat";
+import { useAuth } from "@/lib/api/authContext";
+
+export default function MentoratPage() {
+  const { user } = useAuth();
+  const [demandes, setDemandes] = useState<DemandeMentorat[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchMesDemandes()
+      .then(setDemandes)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleRepondre = async (
+    id: number,
+    statut: "acceptee" | "refusee"
+  ) => {
+    try {
+      const updated = await repondreDemande(id, statut);
+      setDemandes((prev) => prev.map((d) => (d.id === id ? updated : d)));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-4">
+        <span className="loading loading-spinner" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div className="alert alert-error">{error}</div>;
+  }
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Mes demandes de mentorat</h1>
+      <ul className="space-y-2">
+        {demandes.map((d) => (
+          <li key={d.id} className="p-3 bg-base-200 rounded-md space-y-1">
+            <p>
+              <span className="font-semibold">Etudiant:</span> {d.etudiant_username}
+            </p>
+            <p>
+              <span className="font-semibold">Mentor:</span> {d.mentor_username}
+            </p>
+            <p>
+              <span className="font-semibold">Statut:</span> {d.statut}
+            </p>
+            {d.motif_refus && (
+              <p className="text-sm opacity-80">Motif: {d.motif_refus}</p>
+            )}
+            {user?.role === "ALUMNI" &&
+              d.statut === "en_attente" &&
+              d.mentor === user.id && (
+                <div className="flex gap-2 pt-2">
+                  <button
+                    className="btn btn-sm btn-primary"
+                    onClick={() => handleRepondre(d.id, "acceptee")}
+                  >
+                    Accepter
+                  </button>
+                  <button
+                    className="btn btn-sm"
+                    onClick={() => handleRepondre(d.id, "refusee")}
+                  >
+                    Refuser
+                  </button>
+                </div>
+              )}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/web/src/components/UserCard.tsx
+++ b/web/src/components/UserCard.tsx
@@ -1,11 +1,31 @@
 "use client";
+import { useState } from "react";
 import { User } from "@/types/auth";
+import { useAuth } from "@/lib/api/authContext";
+import { envoyerDemande } from "@/lib/api/mentorat";
+import { toast } from "@/components/ui/toast";
 
 interface UserCardProps {
   user: User;
 }
 
 export default function UserCard({ user }: UserCardProps) {
+  const { user: currentUser } = useAuth();
+  const [sent, setSent] = useState(false);
+
+  const canRequest =
+    currentUser?.role === "ETUDIANT" && user.role === "ALUMNI";
+
+  const sendRequest = async () => {
+    try {
+      await envoyerDemande(user.username);
+      setSent(true);
+      toast.success("Demande envoyée");
+    } catch {
+      toast.error("Erreur lors de l'envoi");
+    }
+  };
+
   return (
     <div className="card bg-base-100 shadow-sm">
       <div className="card-body flex items-center gap-4">
@@ -29,6 +49,15 @@ export default function UserCard({ user }: UserCardProps) {
             @{user.username} - {user.role}
           </p>
         </div>
+        {canRequest && (
+          <button
+            className="btn btn-sm ml-auto"
+            onClick={sendRequest}
+            disabled={sent}
+          >
+            {sent ? "Envoyée" : "Demander"}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/ui/side-panel.tsx
+++ b/web/src/components/ui/side-panel.tsx
@@ -36,6 +36,12 @@ const navItems = [
     active: false,
   },
   {
+    label: "Mentorat",
+    icon: <Users size={20} />,
+    href: "/mentorat",
+    active: false,
+  },
+  {
     label: "Membres",
     icon: <Users size={20} />,
     href: "/usersList",

--- a/web/src/lib/api/mentorat.ts
+++ b/web/src/lib/api/mentorat.ts
@@ -1,0 +1,33 @@
+import { api } from "./axios";
+import { DemandeMentorat } from "@/types/mentorat";
+
+export async function envoyerDemande(
+  mentor_username: string,
+  message?: string
+) {
+  const res = await api.post<DemandeMentorat>("/mentorat/envoyer/", {
+    mentor_username,
+    message,
+  });
+  return res.data;
+}
+
+export async function fetchMesDemandes() {
+  const res = await api.get<DemandeMentorat[]>("/mentorat/mes-demandes/");
+  return res.data;
+}
+
+export async function repondreDemande(
+  id: number,
+  statut: "acceptee" | "refusee",
+  motif_refus?: string
+) {
+  const res = await api.patch<DemandeMentorat>(
+    `/mentorat/repondre/${id}/`,
+    {
+      statut,
+      motif_refus,
+    }
+  );
+  return res.data;
+}

--- a/web/src/types/mentorat.d.ts
+++ b/web/src/types/mentorat.d.ts
@@ -1,0 +1,12 @@
+export interface DemandeMentorat {
+  id: number;
+  etudiant: number;
+  etudiant_username: string;
+  mentor: number;
+  mentor_username: string;
+  statut: 'en_attente' | 'acceptee' | 'refusee';
+  message: string | null;
+  motif_refus: string | null;
+  date_demande: string;
+  date_maj: string;
+}


### PR DESCRIPTION
## Summary
- add type and API helper for mentorat
- display mentoring requests page with response actions
- allow students to send mentor requests from user cards
- link to mentorat page in side navigation

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855855763fc83319ba3fc8c9954de1a