### PR TITLE
Add web integrations for backend endpoints

### DIFF
--- a/web/src/app/filiere/page.tsx
+++ b/web/src/app/filiere/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { useEffect, useState } from "react";
+import { fetchFilieres, createFiliere, deleteFiliere, Filiere } from "@/lib/api/filiere";
+import { Input } from "@/components/ui/Input";
+
+export default function FilierePage() {
+  const [filieres, setFilieres] = useState<Filiere[]>([]);
+  const [code, setCode] = useState("");
+  const [nom, setNom] = useState("");
+
+  useEffect(() => {
+    fetchFilieres().then(setFilieres);
+  }, []);
+
+  const handleCreate = async () => {
+    if (!code || !nom) return;
+    const f = await createFiliere({ code, nom_complet: nom });
+    setFilieres((p) => [...p, f]);
+    setCode("");
+    setNom("");
+  };
+
+  const handleDelete = async (id: number) => {
+    await deleteFiliere(id);
+    setFilieres((p) => p.filter((f) => f.id !== id));
+  };
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Filières</h1>
+      <div className="flex gap-2 max-w-md">
+        <Input placeholder="Code" value={code} onChange={(e) => setCode(e.target.value)} />
+        <Input placeholder="Nom" value={nom} onChange={(e) => setNom(e.target.value)} />
+        <button className="btn btn-primary" onClick={handleCreate}>Ajouter</button>
+      </div>
+      <ul className="space-y-2">
+        {filieres.map((f: any) => (
+          <li key={f.id} className="p-2 bg-base-200 rounded-md flex justify-between">
+            <span>
+              {f.code} - {f.nom_complet}
+            </span>
+            <button className="btn btn-xs" onClick={() => handleDelete(f.id)}>Supprimer</button>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/web/src/app/notifications/page.tsx
+++ b/web/src/app/notifications/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+import { useEffect, useState } from "react";
+import { fetchNotifications, openNotificationSocket } from "@/lib/api/notification";
+import { Notification } from "@/types/notification";
+
+export default function NotificationsPage() {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  useEffect(() => {
+    fetchNotifications().then(setNotifications);
+    const ws = openNotificationSocket((n) =>
+      setNotifications((prev) => [n, ...prev])
+    );
+    return () => ws?.close();
+  }, []);
+
+  return (
+    <main className="p-4 space-y-2">
+      <h1 className="text-2xl font-semibold">Notifications</h1>
+      <ul className="space-y-2">
+        {notifications.map((n) => (
+          <li key={n.id} className="p-2 bg-base-200 rounded-md">
+            {n.message}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/web/src/app/parcours/page.tsx
+++ b/web/src/app/parcours/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { useEffect, useState } from "react";
+import {
+  fetchParcoursAcademiques,
+  fetchParcoursProfessionnels,
+} from "@/lib/api/parcours";
+import { ParcoursAcademique, ParcoursProfessionnel } from "@/types/parcours";
+
+export default function ParcoursPage() {
+  const [acad, setAcad] = useState<ParcoursAcademique[]>([]);
+  const [pro, setPro] = useState<ParcoursProfessionnel[]>([]);
+
+  useEffect(() => {
+    fetchParcoursAcademiques().then(setAcad);
+    fetchParcoursProfessionnels().then(setPro);
+  }, []);
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Mon Parcours</h1>
+      <div>
+        <h2 className="text-xl font-semibold mb-2">Académique</h2>
+        <ul className="space-y-1">
+          {acad.map((p) => (
+            <li key={p.id} className="bg-base-200 rounded-md p-2">
+              {p.diplome} - {p.institution} ({p.annee_obtention})
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h2 className="text-xl font-semibold mb-2">Professionnel</h2>
+        <ul className="space-y-1">
+          {pro.map((p) => (
+            <li key={p.id} className="bg-base-200 rounded-md p-2">
+              {p.poste} - {p.entreprise}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/publications/page.tsx
+++ b/web/src/app/publications/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+import { useEffect, useState } from "react";
+import {
+  fetchPublications,
+  createPublication,
+  addComment,
+} from "@/lib/api/publication";
+import { Publication } from "@/types/publication";
+import { Input } from "@/components/ui/Input";
+
+export default function PublicationsPage() {
+  const [publications, setPublications] = useState<Publication[]>([]);
+  const [texte, setTexte] = useState("");
+
+  useEffect(() => {
+    fetchPublications().then(setPublications);
+  }, []);
+
+  const handleCreate = async () => {
+    if (!texte.trim()) return;
+    const data = new FormData();
+    data.append("texte", texte);
+    const pub = await createPublication(data);
+    setPublications((prev) => [pub, ...prev]);
+    setTexte("");
+  };
+
+  const handleComment = async (id: number, value: string) => {
+    if (!value.trim()) return;
+    const pub = await addComment(id, value);
+    setPublications((prev) => prev.map((p) => (p.id === id ? pub : p)));
+  };
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Publications</h1>
+      <div className="flex gap-2">
+        <Input
+          className="flex-1"
+          placeholder="Exprimez-vous..."
+          value={texte}
+          onChange={(e) => setTexte(e.target.value)}
+        />
+        <button className="btn btn-primary" onClick={handleCreate}>
+          Publier
+        </button>
+      </div>
+      <ul className="space-y-4">
+        {publications.map((p) => (
+          <li key={p.id} className="p-3 bg-base-200 rounded-md space-y-2">
+            <p className="font-semibold">{p.auteur_username}</p>
+            {p.texte && <p>{p.texte}</p>}
+            <div className="space-y-1">
+              {p.commentaires.map((c) => (
+                <div key={c.id} className="pl-2 border-l border-base-300">
+                  <p className="text-sm">
+                    <span className="font-semibold">{c.auteur_username}</span> {" "}
+                    {c.contenu}
+                  </p>
+                </div>
+              ))}
+              <CommentForm onAdd={(v) => handleComment(p.id, v)} />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+function CommentForm({ onAdd }: { onAdd: (value: string) => void }) {
+  const [value, setValue] = useState("");
+  return (
+    <div className="flex gap-2 mt-2">
+      <Input
+        className="flex-1"
+        placeholder="Commenter..."
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <button
+        className="btn btn-sm"
+        onClick={() => {
+          onAdd(value);
+          setValue("");
+        }}
+      >
+        Envoyer
+      </button>
+    </div>
+  );
+}

--- a/web/src/app/reports/page.tsx
+++ b/web/src/app/reports/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useEffect, useState } from "react";
+import { fetchReports, banUser, deleteUser } from "@/lib/api/report";
+import { Report } from "@/types/report";
+
+export default function ReportsPage() {
+  const [reports, setReports] = useState<Report[]>([]);
+
+  useEffect(() => {
+    fetchReports().then(setReports);
+  }, []);
+
+  const handleBan = async (id: number) => {
+    await banUser(id);
+    alert("Utilisateur banni");
+  };
+
+  const handleDelete = async (id: number) => {
+    await deleteUser(id);
+    setReports((prev) => prev.filter((r) => r.reported_user.id !== id));
+  };
+
+  return (
+    <main className="p-4 space-y-2">
+      <h1 className="text-2xl font-semibold">Signalements</h1>
+      <ul className="space-y-2">
+        {reports.map((r) => (
+          <li key={r.id} className="p-2 bg-base-200 rounded-md space-y-1">
+            <p>
+              {r.reported_user.username} signalé pour {r.reason}
+            </p>
+            <div className="space-x-2">
+              <button className="btn btn-xs" onClick={() => handleBan(r.reported_user.id)}>
+                Bannir
+              </button>
+              <button className="btn btn-xs" onClick={() => handleDelete(r.reported_user.id)}>
+                Supprimer
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/web/src/app/statistiques/page.tsx
+++ b/web/src/app/statistiques/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { useEffect, useState } from "react";
+import { fetchSituationStats } from "@/lib/api/statistiques";
+import { SituationProStat } from "@/types/stats";
+
+export default function StatistiquesPage() {
+  const [stats, setStats] = useState<SituationProStat[]>([]);
+
+  useEffect(() => {
+    fetchSituationStats().then(setStats);
+  }, []);
+
+  return (
+    <main className="p-4 space-y-2">
+      <h1 className="text-2xl font-semibold">Statistiques</h1>
+      <ul className="space-y-1">
+        {stats.map((s) => (
+          <li key={s.situation} className="p-2 bg-base-200 rounded-md">
+            {s.situation}: {s.count}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/web/src/components/ui/side-panel.tsx
+++ b/web/src/components/ui/side-panel.tsx
@@ -42,6 +42,42 @@ const navItems = [
     active: false,
   },
   {
+    label: "Filieres",
+    icon: <Users size={20} />,
+    href: "/filiere",
+    active: false,
+  },
+  {
+    label: "Publications",
+    icon: <HomeIcon size={20} />,
+    href: "/publications",
+    active: false,
+  },
+  {
+    label: "Notifications",
+    icon: <HomeIcon size={20} />,
+    href: "/notifications",
+    active: false,
+  },
+  {
+    label: "Statistiques",
+    icon: <HomeIcon size={20} />,
+    href: "/statistiques",
+    active: false,
+  },
+  {
+    label: "Reports",
+    icon: <HomeIcon size={20} />,
+    href: "/reports",
+    active: false,
+  },
+  {
+    label: "Parcours",
+    icon: <HomeIcon size={20} />,
+    href: "/parcours",
+    active: false,
+  },
+  {
     label: "Membres",
     icon: <Users size={20} />,
     href: "/usersList",

--- a/web/src/lib/api/filiere.ts
+++ b/web/src/lib/api/filiere.ts
@@ -1,6 +1,7 @@
 import { api } from "./axios";
 
 export interface Filiere {
+  id: number;
   code: string;
   nom_complet: string;
 }
@@ -8,4 +9,13 @@ export interface Filiere {
 export async function fetchFilieres() {
   const res = await api.get<Filiere[]>("/filiere/");
   return res.data;
+}
+
+export async function createFiliere(data: { code: string; nom_complet: string }) {
+  const res = await api.post<Filiere>("/filiere/", data);
+  return res.data;
+}
+
+export async function deleteFiliere(id: number) {
+  await api.delete(`/filiere/${id}/`);
 }

--- a/web/src/lib/api/notification.ts
+++ b/web/src/lib/api/notification.ts
@@ -1,0 +1,18 @@
+import { api } from "./axios";
+import { Notification } from "@/types/notification";
+
+export async function fetchNotifications() {
+  const res = await api.get<Notification[]>("/notifications/");
+  return res.data;
+}
+
+export function openNotificationSocket(onMessage: (n: Notification) => void) {
+  if (typeof window === "undefined") return null;
+  const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+  const ws = new WebSocket(`${protocol}://${window.location.host}/ws/notifications/`);
+  ws.onmessage = (ev) => {
+    const data = JSON.parse(ev.data) as { notification: Notification };
+    onMessage(data.notification);
+  };
+  return ws;
+}

--- a/web/src/lib/api/parcours.ts
+++ b/web/src/lib/api/parcours.ts
@@ -1,0 +1,12 @@
+import { api } from "./axios";
+import { ParcoursAcademique, ParcoursProfessionnel } from "@/types/parcours";
+
+export async function fetchParcoursAcademiques() {
+  const res = await api.get<ParcoursAcademique[]>("/accounts/parcours-academiques/");
+  return res.data;
+}
+
+export async function fetchParcoursProfessionnels() {
+  const res = await api.get<ParcoursProfessionnel[]>("/accounts/parcours-professionnels/");
+  return res.data;
+}

--- a/web/src/lib/api/publication.ts
+++ b/web/src/lib/api/publication.ts
@@ -1,0 +1,28 @@
+import { api } from "./axios";
+import { Publication } from "@/types/publication";
+
+export async function fetchPublications() {
+  const res = await api.get<Publication[]>("/publications/fil/");
+  return res.data;
+}
+
+export async function createPublication(data: FormData) {
+  const res = await api.post<Publication>("/publications/creer/", data);
+  return res.data;
+}
+
+export async function deletePublication(id: number) {
+  await api.delete(`/publications/${id}/supprimer/`);
+}
+
+export async function addComment(publication: number, contenu: string) {
+  const res = await api.post(`/publications/commenter/`, {
+    publication,
+    contenu,
+  });
+  return res.data as Publication;
+}
+
+export async function deleteComment(id: number) {
+  await api.delete(`/publications/commentaire/${id}/supprimer/`);
+}

--- a/web/src/lib/api/report.ts
+++ b/web/src/lib/api/report.ts
@@ -1,0 +1,20 @@
+import { api } from "./axios";
+import { Report } from "@/types/report";
+
+export async function createReport(reported_user_id: number, reason: string) {
+  const res = await api.post<Report>("/reports/report/", { reported_user_id, reason });
+  return res.data;
+}
+
+export async function fetchReports() {
+  const res = await api.get<Report[]>("/reports/reports/");
+  return res.data;
+}
+
+export async function banUser(userId: number) {
+  await api.post(`/reports/ban/${userId}/`);
+}
+
+export async function deleteUser(userId: number) {
+  await api.delete(`/reports/delete/${userId}/`);
+}

--- a/web/src/lib/api/statistiques.ts
+++ b/web/src/lib/api/statistiques.ts
@@ -1,0 +1,12 @@
+import { api } from "./axios";
+import { SituationProStat, DomaineStat } from "@/types/stats";
+
+export async function fetchSituationStats() {
+  const res = await api.get<SituationProStat[]>("/statistiques/situation/");
+  return res.data;
+}
+
+export async function fetchDomaineStats(filiereId: number) {
+  const res = await api.get<DomaineStat[]>(`/statistiques/domaines/${filiereId}/`);
+  return res.data;
+}

--- a/web/src/types/notification.d.ts
+++ b/web/src/types/notification.d.ts
@@ -1,0 +1,6 @@
+export interface Notification {
+  id: number;
+  destinataire: number;
+  message: string;
+  date: string;
+}

--- a/web/src/types/parcours.d.ts
+++ b/web/src/types/parcours.d.ts
@@ -1,0 +1,15 @@
+export interface ParcoursAcademique {
+  id: number;
+  diplome: string;
+  institution: string;
+  annee_obtention: number;
+  mention: string | null;
+}
+
+export interface ParcoursProfessionnel {
+  id: number;
+  poste: string;
+  entreprise: string;
+  date_debut: string;
+  type_contrat: string;
+}

--- a/web/src/types/publication.d.ts
+++ b/web/src/types/publication.d.ts
@@ -1,0 +1,16 @@
+export interface Commentaire {
+  id: number;
+  auteur_username: string;
+  contenu: string;
+  date_commentaire: string;
+}
+
+export interface Publication {
+  id: number;
+  auteur_username: string;
+  texte: string | null;
+  photo: string | null;
+  video: string | null;
+  date_publication: string;
+  commentaires: Commentaire[];
+}

--- a/web/src/types/report.d.ts
+++ b/web/src/types/report.d.ts
@@ -1,0 +1,11 @@
+export interface Report {
+  id: number;
+  reported_by: number;
+  reported_user: {
+    id: number;
+    username: string;
+    email: string;
+  };
+  reason: string;
+  created_at: string;
+}

--- a/web/src/types/stats.d.ts
+++ b/web/src/types/stats.d.ts
@@ -1,0 +1,9 @@
+export interface SituationProStat {
+  situation: string;
+  count: number;
+}
+
+export interface DomaineStat {
+  domaine: string;
+  count: number;
+}


### PR DESCRIPTION
## Summary
- implement realtime notifications and API access
- display feed of publications with comments
- add statistics dashboard
- handle user reports and administrative actions
- manage filieres and user parcours
- expose new API utilities and navigation links

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685587af1cc083318b921c207687bf3a