### PR TITLE
Implement navigation and registration improvements

### DIFF
--- a/web/src/app/auth/signIn/page.tsx
+++ b/web/src/app/auth/signIn/page.tsx
@@ -15,6 +15,9 @@ import type {
 } from "@/types/auth";
 import { useRouter } from "next/navigation";
 import axios from "axios";
+import PersonalInfoForm, { MessageError } from "@/components/auth/PersonalInfoForm";
+import AlumniForm from "@/components/auth/AlumniForm";
+import StudentForm from "@/components/auth/StudentForm";
 
 export default function SignIn() {
   const { login } = useAuth();
@@ -23,6 +26,7 @@ export default function SignIn() {
   const [userType, setUserType] = useState<"student" | "alumni">("alumni");
   const [isPasswordEqual, setIsPasswordEqual] = useState(true);
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [step, setStep] = useState(1);
 
   const currentYear = new Date().getFullYear();
   const years = [];
@@ -253,7 +257,6 @@ export default function SignIn() {
         </h1>
 
         <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Type d'utilisateur */}
           <div className="form-control">
             <label className="block mb-1 text-base-content">
               Type d'utilisateur
@@ -270,279 +273,60 @@ export default function SignIn() {
             </select>
           </div>
 
-          {/* Bloc infos personnelles */}
-          <fieldset className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block mb-1 text-base-content">Nom</label>
-                <input
-                  type="text"
-                  name="nom"
-                  value={user.nom}
-                  onChange={handleUserChange}
-                  required
-                  className="input input-primary"
-                />
-                {messageError.nom &&
-                  messageError.nom.map((msg) => (
-                    <p className="text-error">{msg}</p>
-                  ))}
-              </div>
-              <div>
-                <label className="block mb-1 text-base-content">Prénom</label>
-                <input
-                  type="text"
-                  name="prenom"
-                  value={user.prenom}
-                  onChange={handleUserChange}
-                  required
-                  className="input input-primary"
-                />
-                {messageError.prenom &&
-                  messageError.prenom.map((msg) => (
-                    <p className="text-error">{msg}</p>
-                  ))}
-              </div>
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block mb-1 text-base-content">Email</label>
-                <input
-                  type="email"
-                  name="email"
-                  value={user.email}
-                  onChange={handleUserChange}
-                  required
-                  className="input input-primary"
-                />
-                {messageError.email &&
-                  messageError.email.map((msg) => (
-                    <p className="text-error">{msg}</p>
-                  ))}
-              </div>
-              <div>
-                <label className="block mb-1 text-base-content">
-                  Nom d'utilisateur
-                </label>
-                <input
-                  type="text"
-                  name="username"
-                  value={user.username}
-                  onChange={handleUserChange}
-                  required
-                  className="input input-primary"
-                />
-                {messageError.username &&
-                  messageError.username.map((msg) => (
-                    <p className="text-error">{msg}</p>
-                  ))}
-              </div>
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block mb-1 text-base-content">
-                  Mot de passe
-                </label>
-                <input
-                  type="password"
-                  name="password"
-                  value={user.password}
-                  onChange={handleUserChange}
-                  required
-                  className={`input ${
-                    isPasswordEqual ? "input-primary" : "input-error"
-                  }`}
-                />
-              </div>
-              <div>
-                <label className="block mb-1 text-base-content">
-                  Confirmer le mot de passe
-                </label>
-                <input
-                  type="password"
-                  name="confirmPassword"
-                  onChange={handleConfirmPasswordChange}
-                  required
-                  className={`input ${
-                    isPasswordEqual ? "input-primary" : "input-error"
-                  }`}
-                />
-              </div>
-            </div>
-            {!isPasswordEqual && (
-              <p className="text-red-500 text-sm">
-                Les mots de passe ne correspondent pas.
-              </p>
-            )}
-          </fieldset>
-
-          {/* Bloc spécifique ALUMNI */}
-          {userType === "alumni" ? (
-            <fieldset className="space-y-4">
-              {/* Filière + Situation */}
-              <div className="grid grid-cols-2 gap-4">
-                {/* Sélection du secteur (label « Filière » dans la maquette) – TOUJOURS actif */}
-                <div>
-                  <label className="block mb-1 text-base-content">
-                    Filière
-                  </label>
-                  <select
-                    className="select select-primary"
-                    name="filiere"
-                    value={alumniData.filiere}
-                    onChange={handleAlumniChange}
-                  >
-                    {filieres.map((filiere) => (
-                      <option key={filiere.code} value={filiere.code}>
-                        {filiere.nom_complet}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Situation pro – met à jour isJobSeeking */}
-                <div>
-                  <label className="block mb-1 text-base-content">
-                    Situation professionnelle
-                  </label>
-                  <select
-                    name="situation_pro"
-                    className="select select-primary"
-                    value={alumniData.situation_pro}
-                    onChange={handleSituationChange}
-                  >
-                    <option value="chomage">En recherche d'emploi</option>
-                    <option value="stage">En stage</option>
-                    <option value="emploi">En emploi</option>
-                    <option value="formation">En formation</option>
-                    <option value="autre">Autre</option>
-                  </select>
-                </div>
-              </div>
-
-              {/* Secteur + Poste – désactivés si isJobSeeking */}
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block mb-1 text-base-content">
-                    Secteur d'activité
-                  </label>
-                  <select
-                    className="select select-primary"
-                    name="secteur_activite"
-                    value={alumniData.secteur_activite}
-                    onChange={handleAlumniChange}
-                    disabled={isJobSeeking}
-                  >
-                    {Object.keys(jobBySector).map((key) => (
-                      <option key={key} value={key}>
-                        {key}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div>
-                  <label className="block mb-1 text-base-content">
-                    Poste actuel
-                  </label>
-                  <select
-                    className="select select-primary"
-                    name="poste_actuel"
-                    value={alumniData.poste_actuel}
-                    onChange={handleAlumniChange}
-                    disabled={isJobSeeking}
-                  >
-                    {(
-                      jobBySector[alumniData.secteur_activite as SectorKey] ??
-                      []
-                    ).map((poste) => (
-                      <option key={poste} value={poste}>
-                        {poste}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-
-              {/* Nom entreprise – désactivé si isJobSeeking */}
-              <div>
-                <label className="block mb-1 text-base-content">
-                  Nom de l'entreprise
-                </label>
-                <input
-                  type="text"
-                  name="nom_entreprise"
-                  value={alumniData.nom_entreprise}
-                  onChange={handleAlumniChange}
-                  className="input input-primary"
-                  disabled={isJobSeeking}
-                />
-              </div>
-            </fieldset>
-          ) : (
-            /* Bloc spécifique ÉTUDIANT */
-            <fieldset className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block mb-1 text-base-content">
-                    Filière
-                  </label>
-                  <select
-                    name="filiere"
-                    value={studentData.filiere}
-                    onChange={handleStudentChange}
-                    required
-                    className="select select-primary"
-                  >
-                    {filieres.map((filiere) => (
-                      <option key={filiere.code} value={filiere.code}>
-                        {filiere.nom_complet}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div>
-                  <label className="block mb-1 text-base-content">
-                    Niveau d'étude
-                  </label>
-                  <select
-                    name="niveau_etude"
-                    value={studentData.niveau_etude}
-                    onChange={handleStudentChange}
-                    className="select select-primary"
-                  >
-                    {niveau_etude.map((niv) => (
-                      <option key={niv} value={niv}>
-                        {niv}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-              <div>
-                <label className="block mb-1 text-base-content">
-                  Année d'entrée
-                </label>
-                <select
-                  className="select select-primary"
-                  onChange={handleStudentChange}
-                  name="annee_entree"
-                  value={studentData.annee_entree}
-                >
-                  {years.map((year) => (
-                    <option key={year} value={year}>
-                      {year}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </fieldset>
+          {step === 1 && (
+            <PersonalInfoForm
+              user={user}
+              confirmPassword={confirmPassword}
+              isPasswordEqual={isPasswordEqual}
+              messageError={messageError}
+              onUserChange={handleUserChange}
+              onConfirmPasswordChange={handleConfirmPasswordChange}
+            />
           )}
 
-          <button type="submit" className="w-full btn btn-primary">
-            S'inscrire
-          </button>
+          {step === 2 && (
+            userType === "alumni" ? (
+              <AlumniForm
+                filieres={filieres}
+                alumniData={alumniData}
+                isJobSeeking={isJobSeeking}
+                jobBySector={jobBySector}
+                onAlumniChange={handleAlumniChange}
+                onSituationChange={handleSituationChange}
+              />
+            ) : (
+              <StudentForm
+                filieres={filieres}
+                studentData={studentData}
+                years={years}
+                niveaux={niveau_etude}
+                onStudentChange={handleStudentChange}
+              />
+            )
+          )}
+
+          {step === 1 ? (
+            <button
+              type="button"
+              onClick={() => setStep(2)}
+              className="w-full btn btn-primary"
+            >
+              Suivant
+            </button>
+          ) : (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setStep(1)}
+                className="btn btn-secondary flex-1"
+              >
+                Précédent
+              </button>
+              <button type="submit" className="btn btn-primary flex-1">
+                S'inscrire
+              </button>
+            </div>
+          )}
         </form>
 
         <div className="mt-4 text-sm text-center text-gray-500">

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
   const showSidePanel =
     pathname !== "/auth/login" && pathname !== "/auth/signIn";
   return (
-    <html data-theme="emerald" lang="en" suppressHydrationWarning>
+    <html data-theme="emerald" lang="fr" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/web/src/components/auth/AlumniForm.tsx
+++ b/web/src/components/auth/AlumniForm.tsx
@@ -1,0 +1,106 @@
+'use client';
+import React from 'react';
+import type { Filiere } from '@/lib/api/filiere';
+import type { AlumniRegisterPayload } from '@/types/auth';
+
+export interface AlumniFormProps {
+  filieres: Filiere[];
+  alumniData: Omit<AlumniRegisterPayload, 'user'>;
+  isJobSeeking: boolean;
+  jobBySector: Record<string, string[]>;
+  onAlumniChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
+  onSituationChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+}
+
+export default function AlumniForm({
+  filieres,
+  alumniData,
+  isJobSeeking,
+  jobBySector,
+  onAlumniChange,
+  onSituationChange,
+}: AlumniFormProps) {
+  return (
+    <fieldset className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block mb-1 text-base-content">Filière</label>
+          <select
+            className="select select-primary"
+            name="filiere"
+            value={alumniData.filiere}
+            onChange={onAlumniChange}
+          >
+            {filieres.map((filiere) => (
+              <option key={filiere.code} value={filiere.code}>
+                {filiere.nom_complet}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1 text-base-content">Situation professionnelle</label>
+          <select
+            name="situation_pro"
+            className="select select-primary"
+            value={alumniData.situation_pro}
+            onChange={onSituationChange}
+          >
+            <option value="chomage">En recherche d'emploi</option>
+            <option value="stage">En stage</option>
+            <option value="emploi">En emploi</option>
+            <option value="formation">En formation</option>
+            <option value="autre">Autre</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block mb-1 text-base-content">Secteur d'activité</label>
+          <select
+            className="select select-primary"
+            name="secteur_activite"
+            value={alumniData.secteur_activite}
+            onChange={onAlumniChange}
+            disabled={isJobSeeking}
+          >
+            {Object.keys(jobBySector).map((key) => (
+              <option key={key} value={key}>
+                {key}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1 text-base-content">Poste actuel</label>
+          <select
+            className="select select-primary"
+            name="poste_actuel"
+            value={alumniData.poste_actuel}
+            onChange={onAlumniChange}
+            disabled={isJobSeeking}
+          >
+            {(jobBySector[alumniData.secteur_activite as keyof typeof jobBySector] || []).map((poste) => (
+              <option key={poste} value={poste}>
+                {poste}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <label className="block mb-1 text-base-content">Nom de l'entreprise</label>
+        <input
+          type="text"
+          name="nom_entreprise"
+          value={alumniData.nom_entreprise}
+          onChange={onAlumniChange}
+          className="input input-primary"
+          disabled={isJobSeeking}
+        />
+      </div>
+    </fieldset>
+  );
+}

--- a/web/src/components/auth/PersonalInfoForm.tsx
+++ b/web/src/components/auth/PersonalInfoForm.tsx
@@ -1,0 +1,95 @@
+'use client';
+import React from 'react';
+import { Input } from '@/components/ui/Input';
+import type { UserForm } from '@/types/auth';
+
+export interface MessageError {
+  [key: string]: string[];
+}
+
+interface Props {
+  user: UserForm;
+  confirmPassword: string;
+  isPasswordEqual: boolean;
+  messageError: MessageError;
+  onUserChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onConfirmPasswordChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function PersonalInfoForm({
+  user,
+  confirmPassword,
+  isPasswordEqual,
+  messageError,
+  onUserChange,
+  onConfirmPasswordChange,
+}: Props) {
+  return (
+    <fieldset className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <Input
+          label="Nom"
+          name="nom"
+          value={user.nom}
+          onChange={onUserChange}
+          required
+          className="input input-primary"
+          error={messageError.nom?.join(', ')}
+        />
+        <Input
+          label="Prénom"
+          name="prenom"
+          value={user.prenom}
+          onChange={onUserChange}
+          required
+          className="input input-primary"
+          error={messageError.prenom?.join(', ')}
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <Input
+          label="Email"
+          type="email"
+          name="email"
+          value={user.email}
+          onChange={onUserChange}
+          required
+          className="input input-primary"
+          error={messageError.email?.join(', ')}
+        />
+        <Input
+          label="Nom d'utilisateur"
+          name="username"
+          value={user.username}
+          onChange={onUserChange}
+          required
+          className="input input-primary"
+          error={messageError.username?.join(', ')}
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <Input
+          label="Mot de passe"
+          type="password"
+          name="password"
+          value={user.password}
+          onChange={onUserChange}
+          required
+          className={isPasswordEqual ? 'input input-primary' : 'input input-error'}
+        />
+        <Input
+          label="Confirmer le mot de passe"
+          type="password"
+          name="confirmPassword"
+          value={confirmPassword}
+          onChange={onConfirmPasswordChange}
+          required
+          className={isPasswordEqual ? 'input input-primary' : 'input input-error'}
+        />
+      </div>
+      {!isPasswordEqual && (
+        <p className="text-error">Les mots de passe ne correspondent pas.</p>
+      )}
+    </fieldset>
+  );
+}

--- a/web/src/components/auth/StudentForm.tsx
+++ b/web/src/components/auth/StudentForm.tsx
@@ -1,0 +1,73 @@
+'use client';
+import React from 'react';
+import type { Filiere } from '@/lib/api/filiere';
+import type { StudentRegisterPayload } from '@/types/auth';
+
+export interface StudentFormProps {
+  filieres: Filiere[];
+  studentData: Omit<StudentRegisterPayload, 'user'>;
+  years: number[];
+  niveaux: string[];
+  onStudentChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
+}
+
+export default function StudentForm({
+  filieres,
+  studentData,
+  years,
+  niveaux,
+  onStudentChange,
+}: StudentFormProps) {
+  return (
+    <fieldset className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block mb-1 text-base-content">Filière</label>
+          <select
+            name="filiere"
+            value={studentData.filiere}
+            onChange={onStudentChange}
+            required
+            className="select select-primary"
+          >
+            {filieres.map((filiere) => (
+              <option key={filiere.code} value={filiere.code}>
+                {filiere.nom_complet}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1 text-base-content">Niveau d'étude</label>
+          <select
+            name="niveau_etude"
+            value={studentData.niveau_etude}
+            onChange={onStudentChange}
+            className="select select-primary"
+          >
+            {niveaux.map((niv) => (
+              <option key={niv} value={niv}>
+                {niv}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div>
+        <label className="block mb-1 text-base-content">Année d'entrée</label>
+        <select
+          className="select select-primary"
+          onChange={onStudentChange}
+          name="annee_entree"
+          value={studentData.annee_entree}
+        >
+          {years.map((year) => (
+            <option key={year} value={year}>
+              {year}
+            </option>
+          ))}
+        </select>
+      </div>
+    </fieldset>
+  );
+}

--- a/web/src/components/ui/side-panel.tsx
+++ b/web/src/components/ui/side-panel.tsx
@@ -1,100 +1,95 @@
 "use client";
 
-import React, { useState, ReactNode, useEffect, useRef, act } from "react";
+import React, { useState, ReactNode, useEffect, useRef } from "react";
 import PersonalProfile from "./personal-profile";
 import { useAuth } from "@/lib/api/authContext";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 
 import {
   HomeIcon,
   MessageCircleMore,
   CalendarIcon,
   UserCircleIcon,
-  SettingsIcon,
   LogOutIcon,
   GripHorizontalIcon,
   Users,
+  NewspaperIcon,
+  BellIcon,
+  BarChart2Icon,
+  FileWarningIcon,
+  MapIcon,
+  FileTextIcon,
 } from "lucide-react";
 
 const navItems = [
   {
-    label: "Updates",
-    icon: <HomeIcon size={20} />,
+    label: "Actualités",
+    icon: <NewspaperIcon size={20} />,
     href: "/",
-    active: true,
   },
   {
     label: "Discussions",
     icon: <MessageCircleMore size={20} />,
     href: "/discussions",
-    active: false,
   },
   {
-    label: "Events",
+    label: "Évènements",
     icon: <CalendarIcon size={20} />,
     href: "/evenement",
-    active: false,
   },
   {
     label: "Mentorat",
     icon: <Users size={20} />,
     href: "/mentorat",
-    active: false,
   },
   {
-    label: "Filieres",
+    label: "Filières",
     icon: <Users size={20} />,
     href: "/filiere",
-    active: false,
   },
   {
     label: "Publications",
-    icon: <HomeIcon size={20} />,
+    icon: <FileTextIcon size={20} />,
     href: "/publications",
-    active: false,
   },
   {
     label: "Notifications",
-    icon: <HomeIcon size={20} />,
+    icon: <BellIcon size={20} />,
     href: "/notifications",
-    active: false,
   },
   {
     label: "Statistiques",
-    icon: <HomeIcon size={20} />,
+    icon: <BarChart2Icon size={20} />,
     href: "/statistiques",
-    active: false,
   },
   {
-    label: "Reports",
-    icon: <HomeIcon size={20} />,
+    label: "Rapports",
+    icon: <FileWarningIcon size={20} />,
     href: "/reports",
-    active: false,
   },
   {
     label: "Parcours",
-    icon: <HomeIcon size={20} />,
+    icon: <MapIcon size={20} />,
     href: "/parcours",
-    active: false,
   },
   {
     label: "Membres",
     icon: <Users size={20} />,
     href: "/usersList",
-    active: false,
   },
 ];
 const profileItems = {
-  label: "Profile",
+  label: "Profil",
   icon: <UserCircleIcon size={20} />,
   href: "#",
-  active: false,
 };
 
 export default function SidePanel({ children }: { children: ReactNode }) {
   const [collapsed, setCollapsed] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const panelWidth = collapsed ? "w-16" : "w-50";
+
+  const pathname = usePathname();
 
   const { logout } = useAuth();
   const router = useRouter();
@@ -157,7 +152,7 @@ export default function SidePanel({ children }: { children: ReactNode }) {
               <li
                 key={item.label}
                 className={
-                  item.active
+                  pathname === item.href
                     ? "bg-primary text-primary-content rounded-md"
                     : "hover:bg-base-300 rounded-md"
                 }
@@ -188,7 +183,7 @@ export default function SidePanel({ children }: { children: ReactNode }) {
                 aria-expanded={showProfile}
               >
                 {profileItems.icon}
-                {!collapsed && <span className="text-content">Profile</span>}
+                {!collapsed && <span className="text-content">Profil</span>}
               </button>
             </li>
           </ul>


### PR DESCRIPTION
## Summary
- switch global language to French
- refactor sign-up form into a two‑step flow
- add modular registration form components
- translate navigation labels and use distinct icons
- highlight active navigation link dynamically

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558c61b4d083318bb3d352727f8f62