### PR TITLE
Add theme provider with toggle

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -34,3 +34,9 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Theme Switching
+
+This project uses [`next-themes`](https://github.com/pacocoursey/next-themes) with
+DaisyUI. Use the button in the sidebar to toggle between the `light` and `dark`
+themes. The selected theme is stored on the client and applied on page load.

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -6,6 +6,7 @@ import SidePanel from "../components/ui/side-panel";
 import { usePathname, useRouter } from "next/navigation";
 import { AuthProvider, useAuth } from "@/lib/api/authContext";
 import { useEffect } from "react";
+import { ThemeProvider } from "next-themes";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -31,15 +32,17 @@ export default function RootLayout({
   const showSidePanel =
     pathname !== "/auth/login" && pathname !== "/auth/signIn";
   return (
-    <html data-theme="emerald" lang="fr" suppressHydrationWarning>
+    <html lang="fr" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <AuthProvider>
-          <AuthGuard>
-            {showSidePanel ? <SidePanel>{children}</SidePanel> : children}
-          </AuthGuard>
-        </AuthProvider>
+        <ThemeProvider attribute="data-theme" defaultTheme="light" enableSystem={false}>
+          <AuthProvider>
+            <AuthGuard>
+              {showSidePanel ? <SidePanel>{children}</SidePanel> : children}
+            </AuthGuard>
+          </AuthProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/web/src/components/ui/side-panel.tsx
+++ b/web/src/components/ui/side-panel.tsx
@@ -4,6 +4,7 @@ import React, { useState, ReactNode, useEffect, useRef } from "react";
 import PersonalProfile from "./personal-profile";
 import { useAuth } from "@/lib/api/authContext";
 import { useRouter, usePathname } from "next/navigation";
+import ThemeToggle from "./theme-toggle";
 
 import {
   HomeIcon,
@@ -188,7 +189,8 @@ export default function SidePanel({ children }: { children: ReactNode }) {
             </li>
           </ul>
         </div>
-        <div className="p-2">
+        <div className="p-2 flex flex-col gap-2">
+          <ThemeToggle />
           <button
             onClick={handleLogout}
             className={`flex items-center p-2 w-full hover:bg-base-300 rounded-md ${

--- a/web/src/components/ui/theme-toggle.tsx
+++ b/web/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  const toggle = () => setTheme(theme === "dark" ? "light" : "dark");
+
+  return (
+    <button
+      aria-label="Toggle Theme"
+      className="btn btn-ghost w-full flex items-center justify-center gap-3"
+      onClick={toggle}
+    >
+      {theme === "dark" ? <Sun size={20} /> : <Moon size={20} />}
+      <span className="hidden sm:inline">Thème</span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- enable `next-themes` provider in the main layout
- add a sidebar toggle for DaisyUI dark/light modes
- document theme usage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685591f07ac48331af19f216739426eb