### PR TITLE
Implement responsive drawer for navigation

### DIFF
--- a/web/src/components/ui/side-panel.tsx
+++ b/web/src/components/ui/side-panel.tsx
@@ -13,6 +13,7 @@ import {
   UserCircleIcon,
   LogOutIcon,
   GripHorizontalIcon,
+  Menu,
   Users,
   NewspaperIcon,
   BellIcon,
@@ -130,82 +131,76 @@ export default function SidePanel({ children }: { children: ReactNode }) {
   }, [showProfile]);
 
   return (
-    <div className="flex flex-auto h-screen overflow-hidden">
-      <aside
-        className={`${panelWidth} bg-base-200 border-r border-base-200 flex flex-col justify-between transition-all duration-300`}
-      >
-        <div>
-          <div
-            className={
-              collapsed ? "flex justify-center p-2" : "flex justify-end p-2"
-            }
-          >
+    <div className="drawer md:drawer-open h-screen">
+      <input id="side-panel-drawer" type="checkbox" className="drawer-toggle" />
+      <div className="drawer-content flex flex-col">
+        <header className="navbar bg-base-200 md:hidden">
+          <label htmlFor="side-panel-drawer" className="btn btn-ghost btn-square">
+            <Menu size={20} />
+          </label>
+        </header>
+        <main className="relative flex-1 overflow-auto">
+          {showProfile && <PersonalProfile onClose={handleCloseProfile} />}
+          {children}
+        </main>
+      </div>
+      <div className="drawer-side">
+        <label htmlFor="side-panel-drawer" className="drawer-overlay md:hidden"></label>
+        <aside
+          className={`${panelWidth} bg-base-200 border-r border-base-200 flex flex-col justify-between transition-all duration-300`}
+        >
+          <div>
+            <div className={collapsed ? "flex justify-center p-2" : "flex justify-end p-2"}>
+              <button onClick={() => setCollapsed((c) => !c)} className="btn btn-ghost btn-sm">
+                <GripHorizontalIcon size={20} />
+              </button>
+            </div>
+            <ul className="menu p-2 space-y-1">
+              {navItems.map((item) => (
+                <li
+                  key={item.label}
+                  className={
+                    pathname === item.href
+                      ? "bg-primary text-primary-content rounded-md"
+                      : "hover:bg-base-300 rounded-md"
+                  }
+                >
+                  <a
+                    href={item.href}
+                    className={`flex items-center p-2 w-full btn-primary ${collapsed ? "justify-center" : "gap-3"}`}
+                    onClick={() => showProfile && setShowProfile(false)}
+                  >
+                    {item.icon}
+                    {!collapsed && <span className="text-content">{item.label}</span>}
+                  </a>
+                </li>
+              ))}
+              <li>
+                <button
+                  ref={profileButtonRef}
+                  className={`flex items-center p-2 w-full ${collapsed ? "justify-center" : "gap-3"} hover:bg-base-300 rounded-md`}
+                  onClick={() => setShowProfile((prev) => !prev)}
+                  aria-haspopup="true"
+                  aria-expanded={showProfile}
+                >
+                  {profileItems.icon}
+                  {!collapsed && <span className="text-content">Profil</span>}
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div className="p-2 flex flex-col gap-2">
+            <ThemeToggle />
             <button
-              onClick={() => setCollapsed((c) => !c)}
-              className="btn btn-ghost btn-sm"
+              onClick={handleLogout}
+              className={`flex items-center p-2 w-full hover:bg-base-300 rounded-md ${collapsed ? "justify-center" : "gap-3"}`}
             >
-              <GripHorizontalIcon size={20} />
+              <LogOutIcon size={20} />
+              {!collapsed && <span className="text-content">Déconnexion</span>}
             </button>
           </div>
-
-          <ul className="menu p-2 space-y-1">
-            {navItems.map((item) => (
-              <li
-                key={item.label}
-                className={
-                  pathname === item.href
-                    ? "bg-primary text-primary-content rounded-md"
-                    : "hover:bg-base-300 rounded-md"
-                }
-              >
-                <a
-                  href={item.href}
-                  className={`flex items-center p-2 w-full btn-primary   /* <= nouveau */
-                ${collapsed ? "justify-center" : "gap-3"}   
-                `}
-                  onClick={() => showProfile && setShowProfile(false)}
-                >
-                  {item.icon}
-                  {!collapsed && (
-                    <span className="text-content">{item.label}</span>
-                  )}
-                </a>
-              </li>
-            ))}
-            <li>
-              <button
-                ref={profileButtonRef}
-                className={`flex items-center p-2 w-full   /* <= nouveau */
-                ${
-                  collapsed ? "justify-center" : "gap-3"
-                } hover:bg-base-300 rounded-md`}
-                onClick={() => setShowProfile((prev) => !prev)}
-                aria-haspopup="true"
-                aria-expanded={showProfile}
-              >
-                {profileItems.icon}
-                {!collapsed && <span className="text-content">Profil</span>}
-              </button>
-            </li>
-          </ul>
-        </div>
-        <div className="p-2 flex flex-col gap-2">
-          <ThemeToggle />
-          <button
-            onClick={handleLogout}
-            className={`flex items-center p-2 w-full hover:bg-base-300 rounded-md ${
-              collapsed ? "justify-center" : "gap-3"
-            }`}
-          >
-            <LogOutIcon size={20} />
-            {!collapsed && <span className="text-content">Déconnexion</span>}
-          </button>
-        </div>
-      </aside>
-      <main className="relative flex-1 overflow-auto">
-        {showProfile && <PersonalProfile onClose={handleCloseProfile} />}
-        {children}
-      </main>
+        </aside>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Menu icon import
- convert `SidePanel` to use DaisyUI drawer for small screens
- provide hamburger menu header to toggle drawer

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855937a5ab48331b0a605c55d673b2a