### PR TITLE
Refactor modals to use shared Input component

### DIFF
--- a/web/src/components/AddEventModal.tsx
+++ b/web/src/components/AddEventModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { CalendarIcon, XIcon } from "lucide-react";
+import { Input } from "@/components/ui/Input";
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api/axios";
@@ -74,13 +75,13 @@ export default function AddEventModal({
           <XIcon size={18} />
         </button>
         {error && <div className="alert alert-error">{error}</div>}
-        <input
+        <Input
           name="titre"
           value={form.titre}
           onChange={handleChange}
           placeholder="Titre"
           required
-          className="input input-ghost text-2xl font-bold w-full"
+          className="input-ghost text-2xl font-bold"
         />
         <textarea
           name="description"
@@ -93,24 +94,24 @@ export default function AddEventModal({
         <div className="flex justify-between items-center text-sm gap-4 flex-wrap">
           <div className="flex items-center gap-2 flex-1 min-w-[10rem]">
             <CalendarIcon size={18} />
-            <input
+            <Input
               type="datetime-local"
               name="date_debut"
               value={form.date_debut}
               onChange={handleChange}
               required
-              className="input input-ghost w-full"
+              className="input-ghost"
             />
           </div>
           <div className="flex items-center gap-2 flex-1 min-w-[10rem]">
             <CalendarIcon size={18} />
-            <input
+            <Input
               type="datetime-local"
               name="date_fin"
               value={form.date_fin}
               onChange={handleChange}
               required
-              className="input input-ghost w-full"
+              className="input-ghost"
             />
           </div>
         </div>

--- a/web/src/components/AddGroupModal.tsx
+++ b/web/src/components/AddGroupModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { XIcon } from "lucide-react";
+import { Input } from "@/components/ui/Input";
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
 import { createGroup } from "@/lib/api/group";
@@ -56,13 +57,13 @@ export default function AddGroupModal({ onClose, onCreated }: AddGroupModalProps
           <XIcon size={18} />
         </button>
         {error && <div className="alert alert-error">{error}</div>}
-        <input
+        <Input
           name="nom_groupe"
           value={form.nom_groupe}
           onChange={handleChange}
           placeholder="Nom du groupe"
           required
-          className="input input-ghost w-full"
+          className="input-ghost"
         />
         <textarea
           name="description"

--- a/web/src/components/EditEventModal.tsx
+++ b/web/src/components/EditEventModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { CalendarIcon, XIcon } from "lucide-react";
+import { Input } from "@/components/ui/Input";
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api/axios";
@@ -77,13 +78,13 @@ export default function EditEventModal({ event, onClose, onUpdated }: EditEventM
           <XIcon size={18} />
         </button>
         {error && <div className="alert alert-error">{error}</div>}
-        <input
+        <Input
           name="titre"
           value={form.titre}
           onChange={handleChange}
           placeholder="Titre"
           required
-          className="input input-ghost text-2xl font-bold w-full"
+          className="input-ghost text-2xl font-bold"
         />
         <textarea
           name="description"
@@ -96,24 +97,24 @@ export default function EditEventModal({ event, onClose, onUpdated }: EditEventM
         <div className="flex justify-between items-center text-sm gap-4 flex-wrap">
           <div className="flex items-center gap-2 flex-1 min-w-[10rem]">
             <CalendarIcon size={18} />
-            <input
+            <Input
               type="datetime-local"
               name="date_debut"
               value={form.date_debut}
               onChange={handleChange}
               required
-              className="input input-ghost w-full"
+              className="input-ghost"
             />
           </div>
           <div className="flex items-center gap-2 flex-1 min-w-[10rem]">
             <CalendarIcon size={18} />
-            <input
+            <Input
               type="datetime-local"
               name="date_fin"
               value={form.date_fin}
               onChange={handleChange}
               required
-              className="input input-ghost w-full"
+              className="input-ghost"
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- use `@/components/ui/Input` in AddEventModal
- use `@/components/ui/Input` in EditEventModal
- use `@/components/ui/Input` in AddGroupModal

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685595020fcc833184709cd38af027b3