### PR TITLE
Use dynamic viewport height in auth pages

### DIFF
--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -38,7 +38,7 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-base-200">
+    <div className="min-h-dvh flex items-center justify-center bg-base-200">
       <div className="bg-s p-8 rounded-2xl shadow-xl w-full max-w-md bg-base-100">
         <h2 className="text-2xl font-bold mb-6 text-center">Connexion</h2>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">

--- a/web/src/app/auth/signIn/page.tsx
+++ b/web/src/app/auth/signIn/page.tsx
@@ -248,7 +248,7 @@ export default function SignIn() {
   };
 
   return (
-    <div className="min-h-screen flex w-full items-center justify-center bg-base-200">
+    <div className="min-h-dvh flex w-full items-center justify-center bg-base-200">
       <div
         className={`p-8 rounded-2xl shadow-xl w-full bg-base-100 transition-all duration-500 ease-in-out max-w-max max-h-max`}
       >


### PR DESCRIPTION
## Summary
- ensure auth pages use dynamic viewport height by replacing `min-h-screen` with `min-h-dvh`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855961be6308331914d53a9a691dbd4