### PR TITLE
Wrap pages with consistent container

### DIFF
--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -38,7 +38,7 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-dvh flex items-center justify-center bg-base-200">
+    <div className="min-h-dvh flex items-center justify-center bg-base-200 mx-auto max-w-7xl px-4">
       <div className="bg-s p-8 rounded-2xl shadow-xl w-full max-w-md bg-base-100">
         <h2 className="text-2xl font-bold mb-6 text-center">Connexion</h2>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">

--- a/web/src/app/auth/signIn/page.tsx
+++ b/web/src/app/auth/signIn/page.tsx
@@ -248,7 +248,7 @@ export default function SignIn() {
   };
 
   return (
-    <div className="min-h-dvh flex w-full items-center justify-center bg-base-200">
+    <div className="min-h-dvh flex w-full items-center justify-center bg-base-200 mx-auto max-w-7xl px-4">
       <div
         className={`p-8 rounded-2xl shadow-xl w-full bg-base-100 transition-all duration-500 ease-in-out max-w-max max-h-max`}
       >

--- a/web/src/app/discussions/[username]/page.tsx
+++ b/web/src/app/discussions/[username]/page.tsx
@@ -54,7 +54,7 @@ export default function ConversationPage() {
   }
 
   return (
-    <main className="flex flex-col h-screen p-4">
+    <main className="flex flex-col h-screen mx-auto max-w-7xl px-4 py-4">
       <h2 className="text-xl font-semibold mb-4">
         Conversation avec {conversation.user.prenom} {conversation.user.nom}
       </h2>

--- a/web/src/app/discussions/page.tsx
+++ b/web/src/app/discussions/page.tsx
@@ -23,7 +23,7 @@ export default function DiscussionsPage() {
   }
 
   return (
-    <main className="p-4 space-y-4">
+    <main className="mx-auto max-w-7xl px-4 py-4 space-y-4">
       <h1 className="text-2xl font-semibold">Discussions</h1>
       <ul className="space-y-2">
         {conversations.map((conv) => (

--- a/web/src/app/evenement/page.tsx
+++ b/web/src/app/evenement/page.tsx
@@ -84,7 +84,7 @@ export default function Page() {
   }
 
   return (
-    <main className="p-4 lg:p-8">
+    <main className="mx-auto max-w-7xl px-4 py-4 lg:py-8">
       <div className="mb-4">
         <button
           className={`btn btn-secondary ${showMyEvents ? "btn-active" : "btn-soft"}`}

--- a/web/src/app/filiere/page.tsx
+++ b/web/src/app/filiere/page.tsx
@@ -26,7 +26,7 @@ export default function FilierePage() {
   };
 
   return (
-    <main className="p-4 space-y-4">
+    <main className="mx-auto max-w-7xl px-4 py-4 space-y-4">
       <h1 className="text-2xl font-semibold">Filières</h1>
       <div className="flex gap-2 max-w-md">
         <Input placeholder="Code" value={code} onChange={(e) => setCode(e.target.value)} />

--- a/web/src/app/groupes/[id]/page.tsx
+++ b/web/src/app/groupes/[id]/page.tsx
@@ -35,7 +35,7 @@ export default function GroupeDetailPage() {
   }
 
   return (
-    <main className="flex flex-col h-screen p-4">
+    <main className="flex flex-col h-screen mx-auto max-w-7xl px-4 py-4">
       <h1 className="text-xl font-semibold mb-4">{group.nom_groupe}</h1>
       <div className="flex-1 overflow-y-auto space-y-2">
         {messages.map((m) => (

--- a/web/src/app/groupes/page.tsx
+++ b/web/src/app/groupes/page.tsx
@@ -47,7 +47,7 @@ export default function GroupesPage() {
   }
 
   return (
-    <main className="p-4 space-y-4">
+    <main className="mx-auto max-w-7xl px-4 py-4 space-y-4">
       <h1 className="text-2xl font-semibold">Groupes</h1>
       <button className="btn btn-primary" onClick={() => setShowForm(true)}>
         Créer un groupe

--- a/web/src/app/mentorat/page.tsx
+++ b/web/src/app/mentorat/page.tsx
@@ -42,7 +42,7 @@ export default function MentoratPage() {
   }
 
   return (
-    <main className="p-4 space-y-4">
+    <main className="mx-auto max-w-7xl px-4 py-4 space-y-4">
       <h1 className="text-2xl font-semibold">Mes demandes de mentorat</h1>
       <ul className="space-y-2">
         {demandes.map((d) => (

--- a/web/src/app/notifications/page.tsx
+++ b/web/src/app/notifications/page.tsx
@@ -15,7 +15,7 @@ export default function NotificationsPage() {
   }, []);
 
   return (
-    <main className="p-4 space-y-2">
+    <main className="mx-auto max-w-7xl px-4 py-4 space-y-2">
       <h1 className="text-2xl font-semibold">Notifications</h1>
       <ul className="space-y-2">
         {notifications.map((n) => (

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="h-screen flex flex-col items-center justify-center bg-base-100">
+    <div className="h-screen flex flex-col items-center justify-center bg-base-100 mx-auto max-w-7xl px-4">
       <h1 className="text-4xl font-bold mb-8">
         Bienvenue sur notre plateforme
       </h1>

--- a/web/src/app/parcours/page.tsx
+++ b/web/src/app/parcours/page.tsx
@@ -16,7 +16,7 @@ export default function ParcoursPage() {
   }, []);
 
   return (
-    <main className="p-4 space-y-4">
+    <main className="mx-auto max-w-7xl px-4 py-4 space-y-4">
       <h1 className="text-2xl font-semibold">Mon Parcours</h1>
       <div>
         <h2 className="text-xl font-semibold mb-2">Académique</h2>

--- a/web/src/app/publications/page.tsx
+++ b/web/src/app/publications/page.tsx
@@ -32,7 +32,7 @@ export default function PublicationsPage() {
   };
 
   return (
-    <main className="p-4 space-y-4">
+    <main className="mx-auto max-w-7xl px-4 py-4 space-y-4">
       <h1 className="text-2xl font-semibold">Publications</h1>
       <div className="flex gap-2">
         <Input

--- a/web/src/app/reports/page.tsx
+++ b/web/src/app/reports/page.tsx
@@ -21,7 +21,7 @@ export default function ReportsPage() {
   };
 
   return (
-    <main className="p-4 space-y-2">
+    <main className="mx-auto max-w-7xl px-4 py-4 space-y-2">
       <h1 className="text-2xl font-semibold">Signalements</h1>
       <ul className="space-y-2">
         {reports.map((r) => (

--- a/web/src/app/statistiques/page.tsx
+++ b/web/src/app/statistiques/page.tsx
@@ -11,7 +11,7 @@ export default function StatistiquesPage() {
   }, []);
 
   return (
-    <main className="p-4 space-y-2">
+    <main className="mx-auto max-w-7xl px-4 py-4 space-y-2">
       <h1 className="text-2xl font-semibold">Statistiques</h1>
       <ul className="space-y-1">
         {stats.map((s) => (

--- a/web/src/app/usersList/page.tsx
+++ b/web/src/app/usersList/page.tsx
@@ -33,7 +33,7 @@ export default function UsersListPage() {
   }, [search]);
 
   return (
-    <main className="p-4 space-y-4">
+    <main className="mx-auto max-w-7xl px-4 py-4 space-y-4">
       <div className="max-w-md">
         <Input
           placeholder="Rechercher..."


### PR DESCRIPTION
## Summary
- use `mx-auto max-w-7xl px-4` container classes across pages
- keep layout consistent by padding main sections

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855971514248331a67b08616761a20c