### PR TITLE
Use Next.js Link component

### DIFF
--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { login as loginApi } from "@/lib/api/auth";
 import { useAuth } from "@/lib/api/authContext";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { Input } from "@/components/ui/Input";
 import { toast } from "@/components/ui/toast";
 import "@/app/globals.css";
@@ -67,9 +68,9 @@ export default function LoginPage() {
         </form>
         <div className="mt-4 text-sm text-center text-gray-500">
           Vous n'avez pas de compte ?{" "}
-          <a href="signIn" className="text-blue-600 hover:underline">
+          <Link href="signIn" className="text-blue-600 hover:underline">
             Inscrivez-vous
-          </a>
+          </Link>
         </div>
       </div>
     </div>

--- a/web/src/app/auth/signIn/page.tsx
+++ b/web/src/app/auth/signIn/page.tsx
@@ -14,6 +14,7 @@ import type {
   UserForm,
 } from "@/types/auth";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import axios from "axios";
 import PersonalInfoForm, { MessageError } from "@/components/auth/PersonalInfoForm";
 import AlumniForm from "@/components/auth/AlumniForm";
@@ -331,9 +332,9 @@ export default function SignIn() {
 
         <div className="mt-4 text-sm text-center text-gray-500">
           Vous avez déjà un compte ?{" "}
-          <a href="/auth/login" className="text-blue-600 hover:underline">
+          <Link href="/auth/login" className="text-blue-600 hover:underline">
             Connectez-vous
-          </a>
+          </Link>
         </div>
       </div>
     </div>

--- a/web/src/components/ui/side-panel.tsx
+++ b/web/src/components/ui/side-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, ReactNode, useEffect, useRef } from "react";
+import Link from "next/link";
 import PersonalProfile from "./personal-profile";
 import { useAuth } from "@/lib/api/authContext";
 import { useRouter, usePathname } from "next/navigation";
@@ -165,14 +166,14 @@ export default function SidePanel({ children }: { children: ReactNode }) {
                       : "hover:bg-base-300 rounded-md"
                   }
                 >
-                  <a
+                  <Link
                     href={item.href}
                     className={`flex items-center p-2 w-full btn-primary ${collapsed ? "justify-center" : "gap-3"}`}
                     onClick={() => showProfile && setShowProfile(false)}
                   >
                     {item.icon}
                     {!collapsed && <span className="text-content">{item.label}</span>}
-                  </a>
+                  </Link>
                 </li>
               ))}
               <li>


### PR DESCRIPTION
## Summary
- switch SidePanel navigation items to `<Link>`
- update login and sign-in pages to use `<Link>` for navigation

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559b9f414c8331a424c0fdc2ff2b93