### PR TITLE
Improve accessibility for event modals

### DIFF
--- a/web/src/components/AddEventModal.tsx
+++ b/web/src/components/AddEventModal.tsx
@@ -2,7 +2,7 @@
 import { CalendarIcon, XIcon } from "lucide-react";
 import { Input } from "@/components/ui/Input";
 import { motion } from "framer-motion";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api/axios";
 import { ApiEvent } from "@/types/evenement";
 
@@ -23,6 +23,7 @@ export default function AddEventModal({
   });
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const firstFieldRef = useRef<HTMLInputElement>(null);
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -57,9 +58,16 @@ export default function AddEventModal({
     return () => window.removeEventListener("keydown", esc);
   }, [onClose]);
 
+  useEffect(() => {
+    firstFieldRef.current?.focus();
+  }, []);
+
   return (
     <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40">
       <motion.form
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-event-modal-title"
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.25 }}
@@ -74,6 +82,9 @@ export default function AddEventModal({
         >
           <XIcon size={18} />
         </button>
+        <h2 id="add-event-modal-title" className="sr-only">
+          Créer un évènement
+        </h2>
         {error && <div className="alert alert-error">{error}</div>}
         <Input
           name="titre"
@@ -82,6 +93,7 @@ export default function AddEventModal({
           placeholder="Titre"
           required
           className="input-ghost text-2xl font-bold"
+          ref={firstFieldRef}
         />
         <textarea
           name="description"

--- a/web/src/components/EditEventModal.tsx
+++ b/web/src/components/EditEventModal.tsx
@@ -2,7 +2,7 @@
 import { CalendarIcon, XIcon } from "lucide-react";
 import { Input } from "@/components/ui/Input";
 import { motion } from "framer-motion";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api/axios";
 import { ApiEvent } from "@/types/evenement";
 
@@ -21,6 +21,7 @@ export default function EditEventModal({ event, onClose, onUpdated }: EditEventM
   });
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const firstFieldRef = useRef<HTMLInputElement>(null);
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -57,12 +58,19 @@ export default function EditEventModal({ event, onClose, onUpdated }: EditEventM
     return () => window.removeEventListener("keydown", esc);
   }, [onClose]);
 
+  useEffect(() => {
+    firstFieldRef.current?.focus();
+  }, []);
+
   return (
     <div
       className="absolute inset-0 z-50 flex items-center justify-center bg-black/40"
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
       <motion.form
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="edit-event-modal-title"
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.25 }}
@@ -77,6 +85,9 @@ export default function EditEventModal({ event, onClose, onUpdated }: EditEventM
         >
           <XIcon size={18} />
         </button>
+        <h2 id="edit-event-modal-title" className="sr-only">
+          Modifier l'évènement
+        </h2>
         {error && <div className="alert alert-error">{error}</div>}
         <Input
           name="titre"
@@ -85,6 +96,7 @@ export default function EditEventModal({ event, onClose, onUpdated }: EditEventM
           placeholder="Titre"
           required
           className="input-ghost text-2xl font-bold"
+          ref={firstFieldRef}
         />
         <textarea
           name="description"


### PR DESCRIPTION
## Summary
- add `role`, `aria-modal` and `aria-labelledby` attributes for event modals
- focus the first input when the modal opens

## Testing
- `npm run lint` *(fails: `next` not found)*
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68559cc76c3c8331ace032c5449ae662