### PR TITLE
Replace browser confirm with modal

### DIFF
--- a/web/src/app/evenement/page.tsx
+++ b/web/src/app/evenement/page.tsx
@@ -7,6 +7,7 @@ import AddEventModal from "@/components/AddEventModal";
 import EditEventModal from "@/components/EditEventModal";
 import EventCard from "@/components/EventCard";
 import EventModal from "@/components/EventModal";
+import ConfirmModal from "@/components/ConfirmModal";
 
 export default function Page() {
   const [events, setEvents] = useState<ApiEvent[]>([]);
@@ -16,6 +17,7 @@ export default function Page() {
   const [showForm, setShowForm] = useState(false);
   const [showMyEvents, setShowMyEvents] = useState(false);
   const [editingEvent, setEditingEvent] = useState<ApiEvent | null>(null);
+  const [eventToDelete, setEventToDelete] = useState<ApiEvent | null>(null);
 
   useEffect(() => {
     async function fetchEvents() {
@@ -55,15 +57,23 @@ export default function Page() {
     setEditingEvent(null);
   };
 
-  const handleDelete = async (id: number) => {
-    if (!confirm("Supprimer cet événement ?")) return;
+  const requestDelete = (ev: ApiEvent) => {
+    setEventToDelete(ev);
+  };
+
+  const confirmDelete = async () => {
+    if (!eventToDelete) return;
     try {
-      const res = await api.delete(`/events/evenements/${id}/supprimer/`);
+      const res = await api.delete(
+        `/events/evenements/${eventToDelete.id}/supprimer/`
+      );
       if (res.status >= 200 && res.status < 300) {
-        setEvents((prev) => prev.filter((e) => e.id !== id));
+        setEvents((prev) => prev.filter((e) => e.id !== eventToDelete.id));
       }
     } catch (err) {
       console.error(err);
+    } finally {
+      setEventToDelete(null);
     }
   };
 
@@ -118,7 +128,7 @@ export default function Page() {
             onToggle={() => setSelectedEvent(ev)}
             showActions={showMyEvents}
             onEdit={() => setEditingEvent(ev)}
-            onDelete={() => handleDelete(ev.id)}
+            onDelete={() => requestDelete(ev)}
           />
         ))}
       </div>
@@ -126,6 +136,16 @@ export default function Page() {
         <EventModal
           event={selectedEvent}
           onClose={() => setSelectedEvent(null)}
+        />
+      )}
+      {eventToDelete && (
+        <ConfirmModal
+          title="Supprimer l\'évènement"
+          message={`Supprimer "${eventToDelete.titre}" ?`}
+          confirmText="Supprimer"
+          cancelText="Annuler"
+          onConfirm={confirmDelete}
+          onCancel={() => setEventToDelete(null)}
         />
       )}
       <button

--- a/web/src/components/ConfirmModal.tsx
+++ b/web/src/components/ConfirmModal.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface ConfirmModalProps {
+  title?: string;
+  message?: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm(): void;
+  onCancel(): void;
+}
+
+export default function ConfirmModal({
+  title,
+  message,
+  confirmText = "Confirmer",
+  cancelText = "Annuler",
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={(e) => e.target === e.currentTarget && onCancel()}
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.25 }}
+        className="relative w-full max-w-sm bg-base-100 rounded-lg p-6 shadow-xl space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {title && <h2 className="text-lg font-bold">{title}</h2>}
+        {message && <p className="text-sm opacity-80 whitespace-pre-line">{message}</p>}
+        <div className="flex justify-end gap-2 pt-2">
+          <button className="btn" type="button" onClick={onCancel}>
+            {cancelText}
+          </button>
+          <button className="btn btn-error" type="button" onClick={onConfirm}>
+            {confirmText}
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ConfirmModal` component for generic confirmation dialogs
- use the modal in the Events page instead of `confirm()`
- deletion now waits for user confirmation

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559e1704148331adc0d7700eceda53