### PR TITLE
Add not-found page

### DIFF
--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="h-screen flex flex-col items-center justify-center bg-base-100 mx-auto max-w-7xl px-4">
+      <h1 className="text-4xl font-bold mb-8">Page introuvable</h1>
+      <Link href="/" className="btn btn-primary btn-lg">
+        Retour à l'accueil
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple 404 page showing 'Page introuvable'

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559e249dc0833187b36b2b9c7c42e3