### PR TITLE
Improve web error handling

### DIFF
--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function GlobalError({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="h-screen flex flex-col items-center justify-center bg-base-100 mx-auto max-w-7xl px-4">
+      <h1 className="text-4xl font-bold mb-4">Une erreur est survenue</h1>
+      <button className="btn btn-primary btn-lg" onClick={() => reset()}>
+        Réessayer
+      </button>
+      <Link href="/" className="btn btn-link mt-4">
+        Retour à l'accueil
+      </Link>
+    </div>
+  );
+}

--- a/web/src/lib/api/axios.tsx
+++ b/web/src/lib/api/axios.tsx
@@ -1,4 +1,5 @@
 import axios, { AxiosRequestHeaders } from "axios";
+import { toast } from "@/components/ui/toast";
 
 // Création d’une instance pré‑configurée
 export const api = axios.create({
@@ -21,7 +22,21 @@ api.interceptors.request.use((config) => {
 });
 
 // Intercepteur de réponse : refresh token ou déconnexion automatique
-api.interceptors.response.use((response) => {
-  console.log("Réponse de l'API :", response.data);
-  return response;
-});
+api.interceptors.response.use(
+  (response) => {
+    console.log("Réponse de l'API :", response.data);
+    return response;
+  },
+  (error) => {
+    const message =
+      error.response?.data?.detail ||
+      error.response?.data?.message ||
+      error.message ||
+      "Une erreur est survenue";
+    if (typeof window !== "undefined") {
+      toast.error(message);
+    }
+    console.error("Erreur API :", error);
+    return Promise.reject(error);
+  }
+);


### PR DESCRIPTION
## Summary
- add global error page for the web frontend
- enhance axios interceptor to show toast messages on errors

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855a39f4cd08331811ca3d9999dcfe3