### PR TITLE
Handle missing conversation in DM page

### DIFF
--- a/web/src/app/discussions/[username]/page.tsx
+++ b/web/src/app/discussions/[username]/page.tsx
@@ -18,12 +18,17 @@ export default function ConversationPage() {
 
     fetchMessages(username).then((msgs) => {
       setMessages(msgs);
+      if (!wsRef.current && msgs.length > 0) {
+        const first = msgs[0];
+        const id = first.expediteur_username === username ? first.expediteur : first.destinataire;
+        openSocket(id);
+      }
     });
 
     fetchConversations().then((convs) => {
       const conv = convs.find((c) => c.username === username) || null;
       setConversation(conv);
-      if (conv) {
+      if (conv && !wsRef.current) {
         openSocket(conv.id);
       }
     });

--- a/web/src/app/discussions/page.tsx
+++ b/web/src/app/discussions/page.tsx
@@ -49,7 +49,7 @@ export default function DiscussionsPage() {
                   {conv.prenom} {conv.nom}
                 </p>
                 <p className="text-sm opacity-70 truncate max-w-xs">
-                  {conv.last_message.contenu}
+                  {conv.last_message}
                 </p>
               </div>
             </Link>

--- a/web/src/types/messaging.d.ts
+++ b/web/src/types/messaging.d.ts
@@ -14,7 +14,7 @@ export interface Conversation {
   prenom: string;
   nom: string;
   photo_profil: string | null;
-  last_message: Message;
+  last_message: string | null;
 }
 
 export interface ConversationDetail {


### PR DESCRIPTION
## Summary
- open websocket from messages when conversation info is missing
- fix conversation list preview text
- sync `Conversation` type with backend response

## Testing
- `npx tsc -p web/tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685a91d27530833181e5e3d870af280b