### PR TITLE
Fix discussion websocket URL

### DIFF
--- a/web/src/app/discussions/[username]/page.tsx
+++ b/web/src/app/discussions/[username]/page.tsx
@@ -36,7 +36,9 @@ export default function ConversationPage() {
 
   function openSocket(userId: number) {
     const protocol = window.location.protocol === "https:" ? "wss" : "ws";
-    const ws = new WebSocket(`${protocol}://${window.location.host}/ws/chat/${userId}/`);
+    const ws = new WebSocket(
+      `${protocol}://${window.location.host}/ws/notifications/`
+    );
     wsRef.current = ws;
     ws.onopen = () => setSocketOpen(true);
     ws.onmessage = (event) => {


### PR DESCRIPTION
## Summary
- connect discussion pages to `/ws/notifications/` WebSocket

## Testing
- `npm --prefix web run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab449b9408331ac437bcc364fd96e