### PR TITLE
Use API endpoint for sending messages

### DIFF
--- a/web/src/app/discussions/[username]/page.tsx
+++ b/web/src/app/discussions/[username]/page.tsx
@@ -1,7 +1,11 @@
 "use client";
 import { useEffect, useState, useRef } from "react";
 import { useParams } from "next/navigation";
-import { fetchMessages, fetchConversations } from "@/lib/api/messaging";
+import {
+  fetchMessages,
+  fetchConversations,
+  sendMessage as sendMessageApi,
+} from "@/lib/api/messaging";
 import { Conversation, Message } from "@/types/messaging";
 import { Input } from "@/components/ui/Input";
 
@@ -47,11 +51,10 @@ export default function ConversationPage() {
     };
   }
 
-  function sendMessage() {
-    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN || !content.trim()) {
-      return;
-    }
-    wsRef.current.send(JSON.stringify({ message: content }));
+  async function sendMessage() {
+    if (!content.trim()) return;
+    const msg = await sendMessageApi(username, content);
+    setMessages((prev) => [...prev, msg]);
     setContent("");
   }
 
@@ -88,7 +91,7 @@ export default function ConversationPage() {
         <button
           className="btn btn-primary"
           onClick={sendMessage}
-          disabled={!socketOpen || !content.trim()}
+          disabled={!content.trim()}
         >
           Envoyer
         </button>

--- a/web/src/lib/api/messaging.ts
+++ b/web/src/lib/api/messaging.ts
@@ -10,3 +10,11 @@ export async function fetchMessages(username: string) {
   const res = await api.get<Message[]>(`/messaging/with/${username}/`);
   return res.data;
 }
+
+export async function sendMessage(username: string, contenu: string) {
+  const res = await api.post<Message>("/messaging/envoyer/", {
+    destinataire_username: username,
+    contenu,
+  });
+  return res.data;
+}


### PR DESCRIPTION
## Summary
- add `sendMessage` API helper
- update discussion page to call `sendMessage` API and append returned message
- rely on websocket only for notifications

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac866baf88331ac83f0eff7e1eba5