### PR TITLE
Fix duplicated AuthProvider

### DIFF
--- a/web/src/app/auth/layout.tsx
+++ b/web/src/app/auth/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { usePathname, useRouter } from "next/navigation";
-import { AuthProvider, useAuth } from "@/lib/api/authContext";
+import { useAuth } from "@/lib/api/authContext";
 import { useEffect } from "react";
 
 
@@ -9,11 +9,7 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return (
-    <AuthProvider>
-      <AuthGuard>{children}</AuthGuard>
-    </AuthProvider>
-  );
+  return <AuthGuard>{children}</AuthGuard>;
 }
 
 function AuthGuard({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary
- remove nested `AuthProvider` from `/auth` layout so pages rely on the root provider

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686570ef767483318f533203250cc12d