### PR TITLE
Integrate parcours management on web

### DIFF
--- a/web/src/app/parcours/page.tsx
+++ b/web/src/app/parcours/page.tsx
@@ -4,40 +4,28 @@ import {
   fetchParcoursAcademiques,
   fetchParcoursProfessionnels,
 } from "@/lib/api/parcours";
+import ParcoursAcademiqueSection from "@/components/profile/ParcoursAcademiqueSection";
+import ParcoursProfessionnelSection from "@/components/profile/ParcoursProfessionnelSection";
 import { ParcoursAcademique, ParcoursProfessionnel } from "@/types/parcours";
 
 export default function ParcoursPage() {
   const [acad, setAcad] = useState<ParcoursAcademique[]>([]);
   const [pro, setPro] = useState<ParcoursProfessionnel[]>([]);
 
-  useEffect(() => {
+  const refresh = () => {
     fetchParcoursAcademiques().then(setAcad);
     fetchParcoursProfessionnels().then(setPro);
+  };
+
+  useEffect(() => {
+    refresh();
   }, []);
 
   return (
     <main className="mx-auto max-w-7xl px-4 py-4 space-y-4">
       <h1 className="text-2xl font-semibold">Mon Parcours</h1>
-      <div>
-        <h2 className="text-xl font-semibold mb-2">Académique</h2>
-        <ul className="space-y-1">
-          {acad.map((p) => (
-            <li key={p.id} className="bg-base-200 rounded-md p-2">
-              {p.diplome} - {p.institution} ({p.annee_obtention})
-            </li>
-          ))}
-        </ul>
-      </div>
-      <div>
-        <h2 className="text-xl font-semibold mb-2">Professionnel</h2>
-        <ul className="space-y-1">
-          {pro.map((p) => (
-            <li key={p.id} className="bg-base-200 rounded-md p-2">
-              {p.poste} - {p.entreprise}
-            </li>
-          ))}
-        </ul>
-      </div>
+      <ParcoursAcademiqueSection items={acad} onChanged={refresh} />
+      <ParcoursProfessionnelSection items={pro} onChanged={refresh} />
     </main>
   );
 }

--- a/web/src/components/profile/ParcoursAcademiqueSection.tsx
+++ b/web/src/components/profile/ParcoursAcademiqueSection.tsx
@@ -1,0 +1,175 @@
+"use client";
+import { useState, useRef, useEffect } from "react";
+import { Input } from "@/components/ui/Input";
+import { Pencil, Trash2 } from "lucide-react";
+import {
+  createParcoursAcademique,
+  updateParcoursAcademique,
+  deleteParcoursAcademique,
+} from "@/lib/api/parcours";
+import { ParcoursAcademique } from "@/types/parcours";
+import { motion } from "framer-motion";
+
+interface Props {
+  items: ParcoursAcademique[];
+  onChanged: () => void;
+}
+
+export default function ParcoursAcademiqueSection({ items, onChanged }: Props) {
+  const [showModal, setShowModal] = useState(false);
+  const [editing, setEditing] = useState<ParcoursAcademique | null>(null);
+  const [form, setForm] = useState({
+    diplome: "",
+    institution: "",
+    annee_obtention: "",
+    mention: "",
+  });
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+
+  const openCreate = () => {
+    setEditing(null);
+    setForm({ diplome: "", institution: "", annee_obtention: "", mention: "" });
+    setShowModal(true);
+  };
+  const openEdit = (item: ParcoursAcademique) => {
+    setEditing(item);
+    setForm({
+      diplome: item.diplome,
+      institution: item.institution,
+      annee_obtention: String(item.annee_obtention),
+      mention: item.mention ?? "",
+    });
+    setShowModal(true);
+  };
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const payload = {
+      diplome: form.diplome,
+      institution: form.institution,
+      annee_obtention: parseInt(form.annee_obtention, 10),
+      mention: form.mention || null,
+    } as Omit<ParcoursAcademique, "id">;
+    if (editing) {
+      await updateParcoursAcademique(editing.id, payload);
+    } else {
+      await createParcoursAcademique(payload);
+    }
+    setShowModal(false);
+    onChanged();
+  };
+
+  const handleDelete = async (id: number) => {
+    await deleteParcoursAcademique(id);
+    onChanged();
+  };
+
+  useEffect(() => {
+    if (showModal) firstFieldRef.current?.focus();
+  }, [showModal]);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex justify-between items-center">
+        <h2 className="text-xl font-semibold">Académique</h2>
+        <button className="btn btn-sm btn-primary" onClick={openCreate}>
+          Ajouter
+        </button>
+      </div>
+      <ul className="space-y-1">
+        {items.map((p) => (
+          <li
+            key={p.id}
+            className="bg-base-200 rounded-md p-2 flex justify-between items-center"
+          >
+            <span>
+              {p.diplome} - {p.institution} ({p.annee_obtention})
+            </span>
+            <span className="flex gap-2">
+              <button
+                className="btn btn-xs btn-circle"
+                onClick={() => openEdit(p)}
+              >
+                <Pencil size={14} />
+              </button>
+              <button
+                className="btn btn-xs btn-circle btn-error"
+                onClick={() => handleDelete(p.id)}
+              >
+                <Trash2 size={14} />
+              </button>
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {showModal && (
+        <div
+          className="absolute inset-0 z-50 flex items-center justify-center bg-black/40"
+          onClick={() => setShowModal(false)}
+        >
+          <motion.form
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.25 }}
+            className="bg-base-100 p-6 rounded-lg space-y-4 w-full max-w-sm"
+            onClick={(e) => e.stopPropagation()}
+            onSubmit={handleSubmit}
+          >
+            <h3 className="text-lg font-semibold mb-2">
+              {editing ? "Modifier" : "Ajouter"} un parcours académique
+            </h3>
+            <Input
+              name="diplome"
+              value={form.diplome}
+              onChange={handleChange}
+              placeholder="Diplôme"
+              ref={firstFieldRef}
+              required
+            />
+            <Input
+              name="institution"
+              value={form.institution}
+              onChange={handleChange}
+              placeholder="Institution"
+              required
+            />
+            <Input
+              name="annee_obtention"
+              type="number"
+              value={form.annee_obtention}
+              onChange={handleChange}
+              placeholder="Année d'obtention"
+              required
+            />
+            <Input
+              name="mention"
+              value={form.mention}
+              onChange={handleChange}
+              placeholder="Mention"
+            />
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                onClick={() => setShowModal(false)}
+              >
+                Annuler
+              </button>
+              <button type="submit" className="btn btn-primary btn-sm">
+                {editing ? "Modifier" : "Créer"}
+              </button>
+            </div>
+          </motion.form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/profile/ParcoursProfessionnelSection.tsx
+++ b/web/src/components/profile/ParcoursProfessionnelSection.tsx
@@ -1,0 +1,187 @@
+"use client";
+import { useState, useRef, useEffect } from "react";
+import { Input } from "@/components/ui/Input";
+import { Pencil, Trash2 } from "lucide-react";
+import {
+  createParcoursProfessionnel,
+  updateParcoursProfessionnel,
+  deleteParcoursProfessionnel,
+} from "@/lib/api/parcours";
+import { ParcoursProfessionnel } from "@/types/parcours";
+import { motion } from "framer-motion";
+
+interface Props {
+  items: ParcoursProfessionnel[];
+  onChanged: () => void;
+}
+
+const contrats = [
+  { value: "CDI", label: "CDI" },
+  { value: "CDD", label: "CDD" },
+  { value: "stage", label: "Stage" },
+  { value: "freelance", label: "Freelance" },
+  { value: "autre", label: "Autre" },
+];
+
+export default function ParcoursProfessionnelSection({ items, onChanged }: Props) {
+  const [showModal, setShowModal] = useState(false);
+  const [editing, setEditing] = useState<ParcoursProfessionnel | null>(null);
+  const [form, setForm] = useState({
+    poste: "",
+    entreprise: "",
+    date_debut: "",
+    type_contrat: contrats[0].value,
+  });
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+
+  const openCreate = () => {
+    setEditing(null);
+    setForm({ poste: "", entreprise: "", date_debut: "", type_contrat: contrats[0].value });
+    setShowModal(true);
+  };
+  const openEdit = (item: ParcoursProfessionnel) => {
+    setEditing(item);
+    setForm({
+      poste: item.poste,
+      entreprise: item.entreprise,
+      date_debut: item.date_debut,
+      type_contrat: item.type_contrat,
+    });
+    setShowModal(true);
+  };
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const payload = { ...form } as Omit<ParcoursProfessionnel, "id">;
+    if (editing) {
+      await updateParcoursProfessionnel(editing.id, payload);
+    } else {
+      await createParcoursProfessionnel(payload);
+    }
+    setShowModal(false);
+    onChanged();
+  };
+
+  const handleDelete = async (id: number) => {
+    await deleteParcoursProfessionnel(id);
+    onChanged();
+  };
+
+  useEffect(() => {
+    if (showModal) firstFieldRef.current?.focus();
+  }, [showModal]);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex justify-between items-center">
+        <h2 className="text-xl font-semibold">Professionnel</h2>
+        <button className="btn btn-sm btn-primary" onClick={openCreate}>
+          Ajouter
+        </button>
+      </div>
+      <ul className="space-y-1">
+        {items.map((p) => (
+          <li
+            key={p.id}
+            className="bg-base-200 rounded-md p-2 flex justify-between items-center"
+          >
+            <span>
+              {p.poste} - {p.entreprise}
+            </span>
+            <span className="flex gap-2">
+              <button
+                className="btn btn-xs btn-circle"
+                onClick={() => openEdit(p)}
+              >
+                <Pencil size={14} />
+              </button>
+              <button
+                className="btn btn-xs btn-circle btn-error"
+                onClick={() => handleDelete(p.id)}
+              >
+                <Trash2 size={14} />
+              </button>
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {showModal && (
+        <div
+          className="absolute inset-0 z-50 flex items-center justify-center bg-black/40"
+          onClick={() => setShowModal(false)}
+        >
+          <motion.form
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.25 }}
+            className="bg-base-100 p-6 rounded-lg space-y-4 w-full max-w-sm"
+            onClick={(e) => e.stopPropagation()}
+            onSubmit={handleSubmit}
+          >
+            <h3 className="text-lg font-semibold mb-2">
+              {editing ? "Modifier" : "Ajouter"} un parcours professionnel
+            </h3>
+            <Input
+              name="poste"
+              value={form.poste}
+              onChange={handleChange}
+              placeholder="Poste"
+              ref={firstFieldRef}
+              required
+            />
+            <Input
+              name="entreprise"
+              value={form.entreprise}
+              onChange={handleChange}
+              placeholder="Entreprise"
+              required
+            />
+            <Input
+              name="date_debut"
+              type="date"
+              value={form.date_debut}
+              onChange={handleChange}
+              placeholder="Date début"
+              required
+            />
+            <label className="block text-base-content">
+              <span>Type de contrat</span>
+              <select
+                name="type_contrat"
+                value={form.type_contrat}
+                onChange={handleChange}
+                className="select select-bordered w-full mt-1"
+              >
+                {contrats.map((c) => (
+                  <option key={c.value} value={c.value}>
+                    {c.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                onClick={() => setShowModal(false)}
+              >
+                Annuler
+              </button>
+              <button type="submit" className="btn btn-primary btn-sm">
+                {editing ? "Modifier" : "Créer"}
+              </button>
+            </div>
+          </motion.form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/api/parcours.ts
+++ b/web/src/lib/api/parcours.ts
@@ -10,3 +10,37 @@ export async function fetchParcoursProfessionnels() {
   const res = await api.get<ParcoursProfessionnel[]>("/accounts/parcours-professionnels/");
   return res.data;
 }
+
+export async function createParcoursAcademique(data: Omit<ParcoursAcademique, "id">) {
+  const res = await api.post<ParcoursAcademique>("/accounts/parcours-academiques/", data);
+  return res.data;
+}
+
+export async function updateParcoursAcademique(
+  id: number,
+  data: Partial<Omit<ParcoursAcademique, "id">>
+) {
+  const res = await api.put<ParcoursAcademique>(`/accounts/parcours-academiques/${id}/`, data);
+  return res.data;
+}
+
+export async function deleteParcoursAcademique(id: number) {
+  await api.delete(`/accounts/parcours-academiques/${id}/`);
+}
+
+export async function createParcoursProfessionnel(data: Omit<ParcoursProfessionnel, "id">) {
+  const res = await api.post<ParcoursProfessionnel>("/accounts/parcours-professionnels/", data);
+  return res.data;
+}
+
+export async function updateParcoursProfessionnel(
+  id: number,
+  data: Partial<Omit<ParcoursProfessionnel, "id">>
+) {
+  const res = await api.put<ParcoursProfessionnel>(`/accounts/parcours-professionnels/${id}/`, data);
+  return res.data;
+}
+
+export async function deleteParcoursProfessionnel(id: number) {
+  await api.delete(`/accounts/parcours-professionnels/${id}/`);
+}


### PR DESCRIPTION
## Summary
- add CRUD methods for parcours in web API
- create components to manage academic and professional paths
- update parcours page to use new components

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68679060b7788331a047607dc8601d66