### PR TITLE
Enhance profile page design

### DIFF
--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -25,7 +25,7 @@ export default function ProfilePage() {
   return (
     <div className="p-4 md:p-8">
       <h1 className="text-3xl font-bold mb-8">Mon Espace Personnel</h1>
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
 
         {/* Colonne principale pour les détails du profil et les publications */}
         <div className="lg:col-span-2 space-y-8">

--- a/web/src/components/profile/EditProfileModal.tsx
+++ b/web/src/components/profile/EditProfileModal.tsx
@@ -25,17 +25,23 @@ function buildFields(user: any): ProfileField[] {
 
 interface EditProfileModalProps {
   onClose: () => void;
+  onSaved?: () => void;
 }
 
-export default function EditProfileModal({ onClose }: EditProfileModalProps) {
+export default function EditProfileModal({ onClose, onSaved }: EditProfileModalProps) {
   const { user, updateUser } = useAuth();
   const [fields, setFields] = useState<ProfileField[]>(buildFields(user));
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [selectedCover, setSelectedCover] = useState<File | null>(null);
+  const [coverPreview, setCoverPreview] = useState<string | null>(null);
 
   useEffect(() => {
       if (user?.photo_profil) {
           setPreviewUrl("http://127.0.0.1:8000/" + user.photo_profil);
+      }
+      if (user?.photo_couverture) {
+          setCoverPreview("http://127.0.0.1:8000/" + user.photo_couverture);
       }
   }, [user]);
 
@@ -54,6 +60,18 @@ export default function EditProfileModal({ onClose }: EditProfileModalProps) {
             setPreviewUrl(reader.result as string);
         };
         reader.readAsDataURL(file);
+    }
+  };
+
+  const handleCoverChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    setSelectedCover(file);
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setCoverPreview(reader.result as string);
+      };
+      reader.readAsDataURL(file);
     }
   };
 
@@ -78,6 +96,9 @@ export default function EditProfileModal({ onClose }: EditProfileModalProps) {
     if (selectedFile) {
       data.photo_profil = selectedFile;
     }
+    if (selectedCover) {
+      data.photo_couverture = selectedCover;
+    }
 
     try {
       let newUser = user;
@@ -90,9 +111,11 @@ export default function EditProfileModal({ onClose }: EditProfileModalProps) {
         const updated = await updateProfile(data);
         newUser = { ...newUser, ...updated };
         setSelectedFile(null);
+        setSelectedCover(null);
       }
       updateUser(newUser);
       toast.success("Profil mis à jour");
+      onSaved?.();
     } catch {
       toast.error("Erreur lors de la mise à jour");
     } finally {
@@ -139,6 +162,24 @@ export default function EditProfileModal({ onClose }: EditProfileModalProps) {
                     />
                 </div>
             </div>
+        </div>
+        <div className="mb-6">
+          <label className="label">
+            <span className="label-text">Image de couverture</span>
+          </label>
+          <input
+            type="file"
+            className="file-input file-input-bordered w-full"
+            accept="image/*"
+            onChange={handleCoverChange}
+          />
+          {coverPreview && (
+            <img
+              src={coverPreview}
+              alt="Cover Preview"
+              className="mt-2 h-32 w-full object-cover rounded-lg"
+            />
+          )}
         </div>
         
         <div className="space-y-4">

--- a/web/src/components/profile/MentoratRequests.tsx
+++ b/web/src/components/profile/MentoratRequests.tsx
@@ -48,10 +48,15 @@ export default function MentoratRequests() {
       {demandes.length > 0 ? (
         <ul className="space-y-2">
           {demandes.map((d) => (
-            <li key={d.id} className="p-3 bg-base-200 rounded-lg shadow-sm space-y-1">
-              <p>
-                <span className="font-semibold">Etudiant:</span> {d.etudiant_username}
-              </p>
+            <li key={d.id} className="card card-bordered bg-base-200 shadow-sm p-4 space-y-2">
+              <div className="flex items-center gap-3">
+                <div className="avatar">
+                  <div className="w-8 rounded-full">
+                    <img src={`https://ui-avatars.com/api/?name=${d.etudiant_username}`} />
+                  </div>
+                </div>
+                <p className="font-semibold">{d.etudiant_username}</p>
+              </div>
               <p>
                 <span className="font-semibold">Mentor:</span> {d.mentor_username}
               </p>
@@ -72,7 +77,7 @@ export default function MentoratRequests() {
                       Accepter
                     </button>
                     <button
-                      className="btn btn-sm"
+                      className="btn btn-sm btn-error"
                       onClick={() => handleRepondre(d.id, "refusee")}
                     >
                       Refuser

--- a/web/src/components/profile/ParcoursSection.tsx
+++ b/web/src/components/profile/ParcoursSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState, useRef } from "react";
 import { Input } from "@/components/ui/Input";
-import { Pencil, Plus, Trash2 } from "lucide-react";
+import { Pencil, Plus, Trash2, GraduationCap, Briefcase } from "lucide-react";
 import {
   createParcoursAcademique,
   updateParcoursAcademique,
@@ -53,31 +53,44 @@ const ParcoursItem = ({ item, onDelete, onEdit }: ParcoursItemProps) => {
   return (
     <div
       key={isAcademic ? `ac-${item.id}` : `pro-${item.id}`}
-      className="p-4 rounded-lg bg-base-200 flex justify-between items-start"
+      className="card card-bordered bg-base-200 p-4 flex flex-row justify-between items-start"
     >
-      <div>
+      <div className="flex items-start gap-2">
         {isAcademic ? (
-          <>
-            <p className="font-semibold text-lg">{item.diplome}</p>
-            <p className="text-base-content/80">{item.institution}</p>
-            <p className="text-sm text-base-content/60">
-              Obtenu en {item.annee_obtention}{" "}
-              {item.mention && `- Mention ${Mentions[`mention_${item.mention}` as keyof typeof Mentions]}`}
-            </p>
-          </>
+          <GraduationCap className="mt-1 text-primary" size={20} />
         ) : (
-          <>
-            <p className="font-semibold text-lg">{(item as ParcoursProfessionnel).poste}</p>
-            <p className="text-base-content/80">{(item as ParcoursProfessionnel).entreprise}</p>
-            <p className="text-sm text-base-content/60">Depuis {new Date((item as ParcoursProfessionnel).date_debut).toLocaleDateString()} - {(item as ParcoursProfessionnel).type_contrat}</p>
-          </>
+          <Briefcase className="mt-1 text-primary" size={20} />
         )}
+        <div>
+          {isAcademic ? (
+            <>
+              <p className="font-semibold text-lg">{item.diplome}</p>
+              <p className="text-base-content/80">{item.institution}</p>
+              <p className="text-sm text-base-content/60">
+                Obtenu en {item.annee_obtention}{" "}
+                {item.mention &&
+                  `- Mention ${Mentions[`mention_${item.mention}` as keyof typeof Mentions]}`}
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="font-semibold text-lg">{(item as ParcoursProfessionnel).poste}</p>
+              <p className="text-base-content/80">{(item as ParcoursProfessionnel).entreprise}</p>
+              <p className="text-sm text-base-content/60">
+                Depuis {new Date((item as ParcoursProfessionnel).date_debut).toLocaleDateString()} - {(item as ParcoursProfessionnel).type_contrat}
+              </p>
+            </>
+          )}
+        </div>
       </div>
       <div className="flex gap-2 items-center">
         <button className="btn btn-ghost btn-sm btn-circle" onClick={() => onEdit(item)}>
           <Pencil size={16} />
         </button>
-        <button className="btn btn-ghost btn-sm btn-circle text-error" onClick={() => onDelete(item.id, isAcademic ? 'academic' : 'professional')}>
+        <button
+          className="btn btn-ghost btn-sm btn-circle text-error"
+          onClick={() => onDelete(item.id, isAcademic ? 'academic' : 'professional')}
+        >
           <Trash2 size={16} />
         </button>
       </div>

--- a/web/src/components/profile/ProfileDetails.tsx
+++ b/web/src/components/profile/ProfileDetails.tsx
@@ -8,27 +8,47 @@ import EditProfileModal from "./EditProfileModal";
 export default function ProfileDetails() {
   const { user } = useAuth();
   const [isModalOpen, setModalOpen] = useState(false);
+  const [saved, setSaved] = useState(false);
 
   if (!user) {
     return (
-      <div className="flex justify-center items-center h-full">
-        <span className="loading loading-spinner"></span>
+      <div className="p-6 bg-base-100 rounded-2xl shadow-lg animate-pulse space-y-4">
+        <div className="h-40 bg-base-200 rounded w-full" />
+        <div className="flex items-center space-x-4 mt-4">
+          <div className="w-20 h-20 rounded-full bg-base-200" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 bg-base-200 rounded w-1/3" />
+            <div className="h-3 bg-base-200 rounded w-1/4" />
+          </div>
+        </div>
+        <div className="space-y-2">
+          <div className="h-3 bg-base-200 rounded" />
+          <div className="h-3 bg-base-200 rounded w-5/6" />
+        </div>
       </div>
     );
   }
 
-  const photoUrl = user.photo_profil 
-    ? `http://127.0.0.1:8000/${user.photo_profil}` 
+  const photoUrl = user.photo_profil
+    ? `http://127.0.0.1:8000/${user.photo_profil}`
     : `https://ui-avatars.com/api/?name=${user.prenom}+${user.nom}&background=random`;
+  const coverUrl = user.photo_couverture
+    ? `http://127.0.0.1:8000/${user.photo_couverture}`
+    : 'https://source.unsplash.com/1600x900/?abstract,gradient';
 
   return (
     <>
       <div className="relative bg-base-100 rounded-2xl shadow-lg overflow-hidden">
         {/* -- Background Image -- */}
-        <div 
+        <div
           className="h-40 bg-cover bg-center"
-          style={{ backgroundImage: 'url(https://source.unsplash.com/1600x900/?abstract,gradient)' }}
+          style={{ backgroundImage: `url(${coverUrl})` }}
         ></div>
+        {saved && (
+          <div className="badge badge-success absolute top-2 left-2 animate-bounce">
+            Sauvegardé !
+          </div>
+        )}
 
         {/* -- Edit Button -- */}
         <button 
@@ -65,7 +85,15 @@ export default function ProfileDetails() {
         </div>
       </div>
 
-      {isModalOpen && <EditProfileModal onClose={() => setModalOpen(false)} />}
+      {isModalOpen && (
+        <EditProfileModal
+          onClose={() => setModalOpen(false)}
+          onSaved={() => {
+            setSaved(true);
+            setTimeout(() => setSaved(false), 3000);
+          }}
+        />
+      )}
     </>
   );
 }

--- a/web/src/components/profile/UserPublicationsList.tsx
+++ b/web/src/components/profile/UserPublicationsList.tsx
@@ -10,6 +10,7 @@ export default function UserPublicationsList() {
   const { user } = useAuth();
   const [publications, setPublications] = useState<Publication[]>([]);
   const [loading, setLoading] = useState(true);
+  const [visibleCount, setVisibleCount] = useState(3);
 
   useEffect(() => {
     if (user?.username) {
@@ -44,16 +45,28 @@ export default function UserPublicationsList() {
     <div className="bg-base-100 p-6 rounded-2xl shadow-lg">
       <h3 className="text-xl font-bold mb-4">Mes Publications</h3>
       {publications.length > 0 ? (
-        <ul className="space-y-4">
-          {publications.map((p) => (
-            <li key={p.id}>
-              <PublicationCard
-                publication={p}
-                onComment={(v) => handleComment(p.id, v)}
-              />
-            </li>
-          ))}
-        </ul>
+        <>
+          <ul className="space-y-4">
+            {publications.slice(0, visibleCount).map((p) => (
+              <li key={p.id}>
+                <PublicationCard
+                  publication={p}
+                  onComment={(v) => handleComment(p.id, v)}
+                />
+              </li>
+            ))}
+          </ul>
+          {visibleCount < publications.length && (
+            <div className="text-center mt-4">
+              <button
+                className="btn btn-sm"
+                onClick={() => setVisibleCount((c) => c + 3)}
+              >
+                Charger plus
+              </button>
+            </div>
+          )}
+        </>
       ) : (
         <p className="text-neutral-500 text-center py-8">Vous n'avez encore rien publié.</p>
       )}

--- a/web/src/types/auth.d.ts
+++ b/web/src/types/auth.d.ts
@@ -6,6 +6,7 @@ export interface User {
   prenom:       string;
   role:         string;
   photo_profil: null;
+  photo_couverture?: string | null;
   biographie:   null;
 }
 
@@ -55,6 +56,7 @@ export interface UpdateProfilePayload {
   nom?: string;
   prenom?: string;
   photo_profil?: string;
+  photo_couverture?: string;
   biographie?: string;
 }
 


### PR DESCRIPTION
## Summary
- add skeleton placeholders for profile details
- support uploading profile cover image
- show save badge when profile updated
- improve page layout for tablets
- style parcours items with icons and cards
- add 'load more' button for user publications
- enrich mentorat request cards
- update auth types for profile cover image

## Testing
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686a4d0cfcb88331b8f8be4b2ecdc1ea