### PR TITLE
Remove unoptimized usage for publication images

### DIFF
--- a/web/src/components/AddPublicationModal.tsx
+++ b/web/src/components/AddPublicationModal.tsx
@@ -87,7 +87,6 @@ export default function AddPublicationModal({
                   width={400}
                   height={300}
                   className="w-full h-auto object-cover"
-                  unoptimized
                 />
               ) : (
                 <video src={mediaPreview} controls className="w-full h-auto" />

--- a/web/src/components/PublicationCard.tsx
+++ b/web/src/components/PublicationCard.tsx
@@ -53,7 +53,6 @@ export default function PublicationCard({
                 width={44}
                 height={44}
                 className="object-cover w-full h-full"
-                unoptimized
               />
             ) : (
               <span className="flex items-center justify-center h-full text-lg font-semibold">
@@ -98,7 +97,6 @@ export default function PublicationCard({
               width={640}
               height={320}
               className="w-full h-full object-cover"
-              unoptimized
             />
           </div>
         )}
@@ -151,7 +149,6 @@ export default function PublicationCard({
                             width={32}
                             height={32}
                             className="object-cover w-full h-full"
-                            unoptimized
                           />
                         ) : (
                           <span className="text-xs font-semibold">

--- a/web/src/components/PublicationModal.tsx
+++ b/web/src/components/PublicationModal.tsx
@@ -27,7 +27,7 @@ export default function PublicationModal({ publication, onClose }: PublicationMo
         <div className="flex items-center gap-3 mb-4">
           <div className="avatar">
               <div className="w-10 h-10 rounded-full">
-                  <Image src={avatarUrl} alt={`Avatar de ${publication.auteur_username}`} width={40} height={40} unoptimized />
+                  <Image src={avatarUrl} alt={`Avatar de ${publication.auteur_username}`} width={40} height={40} />
               </div>
           </div>
           <div>
@@ -41,7 +41,7 @@ export default function PublicationModal({ publication, onClose }: PublicationMo
           
           {publication.photo && (
             <figure className="mt-2">
-              <Image src={publication.photo} alt="Image de la publication" width={800} height={600} className="w-full h-auto rounded-lg object-contain" unoptimized />
+              <Image src={publication.photo} alt="Image de la publication" width={800} height={600} className="w-full h-auto rounded-lg object-contain" />
             </figure>
           )}
 


### PR DESCRIPTION
## Summary
- remove `unoptimized` from publication images
- keep allowed domains for external images

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed22b2ca88331b9cc618a18247fcb