### PR TITLE
Ajoute un graphe sur la page statistiques

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@hookform/resolvers": "^5.1.1",
         "axios": "^1.9.0",
+        "chart.js": "^4.4.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.10.0",
         "lucide-react": "^0.507.0",
         "next": "^15.3.1",
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.59.0",
         "react-select": "^5.10.1",
@@ -1053,6 +1055,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.10",
@@ -2699,6 +2707,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chownr": {
@@ -6122,6 +6142,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,9 @@
     "styled-components": "^6.1.17",
     "tailwind-merge": "^3.3.0",
     "zod": "^3.25.67",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.3.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/web/src/app/statistiques/page.tsx
+++ b/web/src/app/statistiques/page.tsx
@@ -2,6 +2,15 @@
 import { useEffect, useState } from "react";
 import { fetchSituationStats } from "@/lib/api/statistiques";
 import { SituationProStat } from "@/types/stats";
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Pie } from "react-chartjs-2";
+
+ChartJS.register(ArcElement, Tooltip, Legend);
 
 export default function StatistiquesPage() {
   const [stats, setStats] = useState<SituationProStat[]>([]);
@@ -10,9 +19,30 @@ export default function StatistiquesPage() {
     fetchSituationStats().then(setStats);
   }, []);
 
+  const data = {
+    labels: stats.map((s) => s.situation),
+    datasets: [
+      {
+        label: "Alumnis",
+        data: stats.map((s) => s.count),
+        backgroundColor: [
+          "#93c5fd",
+          "#fda4af",
+          "#34d399",
+          "#fcd34d",
+          "#c084fc",
+          "#fca5a5",
+        ],
+      },
+    ],
+  };
+
   return (
-    <main className="mx-auto max-w-7xl px-4 py-4 space-y-2">
+    <main className="mx-auto max-w-7xl px-4 py-4 space-y-4">
       <h1 className="text-2xl font-semibold">Statistiques</h1>
+      <div className="card bg-base-200 p-4">
+        <Pie data={data} />
+      </div>
       <ul className="space-y-1">
         {stats.map((s) => (
           <li key={s.situation} className="p-2 bg-base-200 rounded-md">


### PR DESCRIPTION
## Summary
- add chart.js and react-chartjs-2 dependencies
- display statistics with a pie chart on `statistiques`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68725e2198fc8331bcfb9f4dbd75cbe9