### PR TITLE
Remove modal close buttons & add image clear

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,5 +1,4 @@
 "use client";
-import type { Metadata } from "next";
 // Disabled next/font usage to avoid network font fetching during build
 import "./globals.css";
 import SidePanel from "../components/ui/side-bar";

--- a/web/src/components/AddEventModal.tsx
+++ b/web/src/components/AddEventModal.tsx
@@ -98,13 +98,6 @@ export default function AddEventModal({
         onClick={(e) => e.stopPropagation()}
         onSubmit={handleSubmit}
       >
-        <button
-          className="btn btn-sm btn-circle absolute top-2 right-2 z-10"
-          type="button"
-          onClick={onClose}
-        >
-          <XIcon size={18} />
-        </button>
         <h2 id="add-event-modal-title" className="sr-only">
           Créer un évènement
         </h2>
@@ -127,7 +120,18 @@ export default function AddEventModal({
           className="textarea textarea-ghost w-full text-sm opacity-80 h-32"
         />
         {imagePreview && (
-          <div className="rounded-lg overflow-hidden border border-base-300/50">
+          <div className="relative rounded-lg overflow-hidden border border-base-300/50">
+            <button
+              type="button"
+              className="btn btn-sm btn-circle absolute top-2 right-2 z-10"
+              onClick={() => {
+                setForm((f) => ({ ...f, image: undefined }));
+                setImagePreview(null);
+                if (fileInputRef.current) fileInputRef.current.value = "";
+              }}
+            >
+              <XIcon size={18} />
+            </button>
             <Image
               src={imagePreview}
               alt="Aperçu"

--- a/web/src/components/AddGroupModal.tsx
+++ b/web/src/components/AddGroupModal.tsx
@@ -82,17 +82,21 @@ export default function AddGroupModal({
         onClick={(e) => e.stopPropagation()}
         onSubmit={handleSubmit}
       >
-        <button
-          type="button"
-          className="btn btn-sm btn-circle absolute top-2 right-2 z-10"
-          onClick={onClose}
-        >
-          <XIcon size={18} />
-        </button>
         {error && <div className="alert alert-error">{error}</div>}
 
         {imagePreview && (
-          <div className="rounded-lg overflow-hidden border border-base-300/50">
+          <div className="relative rounded-lg overflow-hidden border border-base-300/50">
+            <button
+              type="button"
+              className="btn btn-sm btn-circle absolute top-2 right-2 z-10"
+              onClick={() => {
+                setImage(null);
+                setImagePreview(null);
+                if (fileInputRef.current) fileInputRef.current.value = "";
+              }}
+            >
+              <XIcon size={18} />
+            </button>
             <Image
               src={imagePreview}
               alt="Aperçu"

--- a/web/src/components/AddPublicationModal.tsx
+++ b/web/src/components/AddPublicationModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react";
-import { Image as ImageIcon } from "lucide-react";
+import { Image as ImageIcon, X as XIcon } from "lucide-react";
 import Image from "next/image";
 
 interface AddPublicationModalProps {
@@ -60,19 +60,30 @@ export default function AddPublicationModal({
   const mediaType = media?.type.startsWith("video/") ? "video" : "image";
 
   return (
-    <div className="modal modal-open modal-bottom sm:modal-middle">
-      <div className="modal-box relative">
-        <button
-          onClick={onClose}
-          className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2 z-10"
-        >
-          ✕
-        </button>
+    <div
+      className="modal modal-open modal-bottom sm:modal-middle"
+      onClick={onClose}
+    >
+      <div
+        className="modal-box relative"
+        onClick={(e) => e.stopPropagation()}
+      >
         <h3 className="font-bold text-lg mb-4">Créer une publication</h3>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {mediaPreview && (
-            <div className="rounded-lg overflow-hidden border border-base-300/50">
+            <div className="relative rounded-lg overflow-hidden border border-base-300/50">
+              <button
+                type="button"
+                className="btn btn-sm btn-circle absolute top-2 right-2 z-10"
+                onClick={() => {
+                  setMedia(null);
+                  setMediaPreview(null);
+                  if (fileInputRef.current) fileInputRef.current.value = "";
+                }}
+              >
+                <XIcon size={18} />
+              </button>
               {mediaType === "image" ? (
                 <Image
                   src={mediaPreview}
@@ -125,9 +136,6 @@ export default function AddPublicationModal({
             onChange={handleMediaChange}
           />
         </form>
-      </div>
-      <div className="modal-backdrop">
-        <button onClick={onClose}>close</button>
       </div>
     </div>
   );

--- a/web/src/components/EditEventModal.tsx
+++ b/web/src/components/EditEventModal.tsx
@@ -1,4 +1,4 @@
-import { CalendarIcon, XIcon } from "lucide-react";
+import { CalendarIcon } from "lucide-react";
 import { Input } from "@/components/ui/Input";
 import { motion } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
@@ -89,13 +89,6 @@ export default function EditEventModal({
         onClick={(e) => e.stopPropagation()}
         onSubmit={handleSubmit}
       >
-        <button
-          className="btn btn-sm btn-circle absolute top-2 right-2 z-10"
-          type="button"
-          onClick={onClose}
-        >
-          <XIcon size={18} />
-        </button>
         <h2 id="edit-event-modal-title" className="sr-only">
           Modifier l&apos;évènement
         </h2>

--- a/web/src/components/EventModal.tsx
+++ b/web/src/components/EventModal.tsx
@@ -1,4 +1,4 @@
-import { CalendarIcon, XIcon } from "lucide-react";
+import { CalendarIcon } from "lucide-react";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import { useEffect } from "react";
@@ -70,12 +70,6 @@ export default function EventModal({ event, onClose }: EventModalProps) {
             </div>
           </div>
         </div>
-        <button
-          className="btn btn-sm btn-circle absolute top-2 right-2 z-10"
-          onClick={onClose}
-        >
-          <XIcon size={18} />
-        </button>
       </motion.div>
     </div>
   );

--- a/web/src/components/ExternalProfileModal.tsx
+++ b/web/src/components/ExternalProfileModal.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { motion } from "framer-motion";
-import { XIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useAuth } from "@/lib/api/authContext";
@@ -70,13 +69,6 @@ export default function ExternalProfileModal({
         className="relative w-full max-w-sm bg-base-100 rounded-2xl p-8 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <button
-          className="btn btn-sm btn-circle btn-ghost absolute top-3 right-3 z-10"
-          type="button"
-          onClick={onClose}
-        >
-          <XIcon size={20} />
-        </button>
 
         <div className="flex flex-col items-center text-center">
           <Link href={`/profile/${user.username}`} onClick={onClose}>

--- a/web/src/components/GroupDetailModal.tsx
+++ b/web/src/components/GroupDetailModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { motion } from "framer-motion";
-import { XIcon, Users, Calendar } from "lucide-react";
+import { Users, Calendar } from "lucide-react";
 import Image from "next/image";
 import { Group } from "@/types/group";
 
@@ -70,13 +70,6 @@ export default function GroupDetailModal({
             </div>
           </div>
         </div>
-        <button
-          className="btn btn-sm btn-circle btn-ghost absolute top-3 right-3 z-10"
-          type="button"
-          onClick={onClose}
-        >
-          <XIcon size={20} />
-        </button>
       </motion.div>
     </div>
   );

--- a/web/src/components/PublicationModal.tsx
+++ b/web/src/components/PublicationModal.tsx
@@ -1,6 +1,5 @@
 import { Publication } from "@/types/publication";
 import { formatTimeAgo } from "@/lib/utils";
-import { X } from "lucide-react";
 import Image from "next/image";
 
 interface PublicationModalProps {
@@ -23,12 +22,6 @@ export default function PublicationModal({
   return (
     <div className={`modal ${publication ? "modal-open" : ""}`}>
       <div className="modal-box w-11/12 max-w-3xl relative">
-        <button
-          onClick={onClose}
-          className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2 z-10"
-        >
-          <X size={24} />
-        </button>
 
         <div className="flex items-center gap-3 mb-4">
           <div className="avatar">
@@ -81,9 +74,7 @@ export default function PublicationModal({
           )}
         </div>
       </div>
-      <form method="dialog" className="modal-backdrop">
-        <button onClick={onClose}>close</button>
-      </form>
+      <form method="dialog" className="modal-backdrop" onClick={onClose}></form>
     </div>
   );
 }

--- a/web/src/components/profile/ParcoursAcademiqueSection.tsx
+++ b/web/src/components/profile/ParcoursAcademiqueSection.tsx
@@ -118,18 +118,13 @@ export default function ParcoursAcademiqueSection({ items, onChanged }: Props) {
         ))}
         {items.length === 0 && (
           <p className="text-center text-base-content/60 py-4">
-            Aucun parcours académique n'a été ajouté pour le moment.
+            Aucun parcours académique n&apos;a été ajouté pour le moment.
           </p>
         )}
       </div>
 
       <dialog ref={dialogRef} className="modal">
         <div className="modal-box">
-          <form method="dialog">
-            <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
-              ✕
-            </button>
-          </form>
           <h3 className="font-bold text-lg mb-4">
             {editing ? "Modifier le parcours" : "Ajouter un parcours"}{" "}
             académique

--- a/web/src/components/profile/ParcoursProfessionnelSection.tsx
+++ b/web/src/components/profile/ParcoursProfessionnelSection.tsx
@@ -107,9 +107,6 @@ export default function ParcoursProfessionnelSection({ items, onChanged }: Props
 
       <dialog ref={dialogRef} className="modal">
         <div className="modal-box">
-          <form method="dialog">
-            <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-          </form>
           <h3 className="font-bold text-lg mb-4">
             {editing ? "Modifier le parcours" : "Ajouter un parcours"} professionnel
           </h3>

--- a/web/src/components/profile/ParcoursSection.tsx
+++ b/web/src/components/profile/ParcoursSection.tsx
@@ -237,11 +237,6 @@ export default function ParcoursSection({ academicItems, professionalItems, onCh
 
       <dialog ref={dialogRef} className="modal">
         <div className="modal-box">
-          <form method="dialog">
-            <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" onClick={() => dialogRef.current?.close()}>
-              ✕
-            </button>
-          </form>
           <h3 className="font-bold text-lg mb-4">
             {editing ? 'Modifier le' : 'Ajouter un'} parcours {formType === 'academic' ? 'académique' : 'professionnel'}
           </h3>


### PR DESCRIPTION
## Summary
- remove close buttons from modal components
- allow uploaded images to be cleared with a new button
- fix lint issues in the web project

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872ad02fa4883318f5ef9081dcfe26c