### PR TITLE
refactor event fetching

### DIFF
--- a/web/src/app/evenement/page.tsx
+++ b/web/src/app/evenement/page.tsx
@@ -8,7 +8,7 @@ import EventCard from "@/components/EventCard";
 import EventModal from "@/components/EventModal";
 import ConfirmModal from "@/components/ConfirmModal";
 import {
-  fetchAllEvents,
+  fetchEvents,
   fetchPendingEvents,
   deleteEvent,
 } from "@/lib/api/evenement";
@@ -26,25 +26,18 @@ export default function Page() {
   const [eventToDelete, setEventToDelete] = useState<ApiEvent | null>(null);
 
   useEffect(() => {
-    async function fetchEvents() {
-      setLoading(true);
-      try {
-        const data = showPendingEvents
-          ? await fetchPendingEvents()
-          : await fetchAllEvents();
-        setEvents(data);
-      } catch (err: unknown) {
+    setLoading(true);
+    const fetcher = showPendingEvents ? fetchPendingEvents : fetchEvents;
+    fetcher()
+      .then(setEvents)
+      .catch((err: unknown) => {
         if (err instanceof Error) {
           setError(err.message);
         } else {
           setError("Erreur inconnue");
         }
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchEvents();
+      })
+      .finally(() => setLoading(false));
   }, [showPendingEvents]);
 
   const handleCreated = (ev: ApiEvent) => {

--- a/web/src/components/home/UpcomingEvents.tsx
+++ b/web/src/components/home/UpcomingEvents.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { fetchAllEvents } from "@/lib/api/evenement";
+import { fetchEvents } from "@/lib/api/evenement";
 import { ApiEvent } from "@/types/evenement";
 import { Carousel } from "@/components/ui/carousel";
 import EventCard from "@/components/EventCard";
@@ -11,7 +11,7 @@ export default function UpcomingEvents() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchAllEvents()
+    fetchEvents()
       .then((e) => setEvents(e.slice(0, 5))) // Affiche les 5 prochains
       .catch(console.error)
       .finally(() => setLoading(false));

--- a/web/src/lib/api/evenement.ts
+++ b/web/src/lib/api/evenement.ts
@@ -1,7 +1,7 @@
 import { api } from "./axios";
 import { ApiEvent } from "@/types/evenement";
 
-export const fetchAllEvents = async (): Promise<ApiEvent[]> => {
+export const fetchEvents = async (): Promise<ApiEvent[]> => {
     const res = await api.get<ApiEvent[]>("/events/evenements/");
     if (res.status < 200 || res.status >= 300) {
         throw new Error("Impossible de récupérer les événements");


### PR DESCRIPTION
## Summary
- rename API `fetchAllEvents` to `fetchEvents`
- simplify event page data retrieval logic
- update home component with new API function

## Testing
- `npm run lint`
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6872c4d857c88331ae408b3387c8b3bd