### PR TITLE
Add delete capability for web publications

### DIFF
--- a/web/src/components/PublicationCard.tsx
+++ b/web/src/components/PublicationCard.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from "@/lib/api/authContext";
 import { useProfileModal } from "@/contexts/ProfileModalContext";
 import { Publication } from "@/types/publication";
-import { MessageCircle } from "lucide-react";
+import { MessageCircle, Trash2 } from "lucide-react";
 import { useState } from "react";
 import Image from "next/image";
 import { formatTimeAgo } from "@/lib/utils";
@@ -10,12 +10,16 @@ interface PublicationCardProps {
   publication: Publication;
   onComment: (value: string) => void;
   onCardClick?: () => void;
+  onDelete?: () => void;
+  onDeleteComment?: (commentId: number) => void;
 }
 
 export default function PublicationCard({
   publication,
   onComment,
   onCardClick,
+  onDelete,
+  onDeleteComment,
 }: PublicationCardProps) {
   const { user } = useAuth();
   const { showProfile } = useProfileModal();
@@ -39,9 +43,20 @@ export default function PublicationCard({
 
   return (
     <article
-      className={`bg-base-100 border border-base-300/50 rounded-xl p-4 sm:p-5 mb-4 shadow-md flex flex-col ${onCardClick ? "cursor-pointer hover:border-primary/50 transition-colors" : ""}`}
+      className={`relative bg-base-100 border border-base-300/50 rounded-xl p-4 sm:p-5 mb-4 shadow-md flex flex-col ${onCardClick ? "cursor-pointer hover:border-primary/50 transition-colors" : ""}`}
       onClick={onCardClick}
     >
+      {user?.username === publication.auteur_username && onDelete && (
+        <button
+          className="btn btn-xs btn-error absolute top-2 right-2 z-10"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+        >
+          <Trash2 size={16} />
+        </button>
+      )}
       {/* En-tête de la publication */}
       <div className="flex items-start gap-3">
         <div className="avatar">
@@ -164,11 +179,22 @@ export default function PublicationCard({
                         )}
                       </div>
                     </div>
-                    <div className="bg-base-200/60 rounded-lg px-3 py-2 w-full">
+                    <div className="bg-base-200/60 rounded-lg px-3 py-2 w-full flex justify-between items-start">
                       <span className="font-bold mr-2">
                         {c.auteur_username}
                       </span>
-                      <span>{c.contenu}</span>
+                      <span className="flex-1 break-words">{c.contenu}</span>
+                      {onDeleteComment &&
+                        user &&
+                        (user.username === c.auteur_username ||
+                          user.username === publication.auteur_username) && (
+                          <button
+                            className="btn btn-ghost btn-xs text-error"
+                            onClick={() => onDeleteComment(c.id)}
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        )}
                     </div>
                   </div>
                 ))

--- a/web/src/components/home/PublicationsFeed.tsx
+++ b/web/src/components/home/PublicationsFeed.tsx
@@ -1,18 +1,24 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { fetchPublications } from "@/lib/api/publication";
+import {
+  fetchPublications,
+  deletePublication,
+  deleteComment,
+} from "@/lib/api/publication";
 import { Publication } from "@/types/publication";
 import { Carousel } from "@/components/ui/carousel";
 import PublicationCard from "../PublicationCard";
 import PublicationModal from "../PublicationModal";
 import { addComment } from "@/lib/api/publication";
+import ConfirmModal from "../ConfirmModal";
 
 export default function PublicationsFeed() {
   const [publications, setPublications] = useState<Publication[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedPublication, setSelectedPublication] =
     useState<Publication | null>(null);
+  const [toDelete, setToDelete] = useState<Publication | null>(null);
 
   const handleComment = async (id: number, value: string) => {
     if (!value.trim()) return;
@@ -23,6 +29,42 @@ export default function PublicationsFeed() {
     if (selectedPublication?.id === id) {
       setSelectedPublication((prev) => (prev ? { ...prev, ...pub } : null));
     }
+  };
+
+  const handleDeleteComment = async (pubId: number, commentId: number) => {
+    await deleteComment(commentId);
+    setPublications((prev) =>
+      prev.map((p) =>
+        p.id === pubId
+          ? {
+              ...p,
+              commentaires: p.commentaires.filter((c) => c.id !== commentId),
+              nombres_commentaires: (p.nombres_commentaires || 1) - 1,
+            }
+          : p
+      )
+    );
+    if (selectedPublication?.id === pubId) {
+      setSelectedPublication((prev) =>
+        prev
+          ? {
+              ...prev,
+              commentaires: prev.commentaires.filter((c) => c.id !== commentId),
+              nombres_commentaires: (prev.nombres_commentaires || 1) - 1,
+            }
+          : null
+      );
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!toDelete) return;
+    await deletePublication(toDelete.id);
+    setPublications((prev) => prev.filter((p) => p.id !== toDelete.id));
+    if (selectedPublication?.id === toDelete.id) {
+      setSelectedPublication(null);
+    }
+    setToDelete(null);
   };
 
   useEffect(() => {
@@ -51,6 +93,8 @@ export default function PublicationsFeed() {
                 publication={p}
                 onComment={(v) => handleComment(p.id, v)}
                 onCardClick={() => setSelectedPublication(p)}
+                onDelete={() => setToDelete(p)}
+                onDeleteComment={(cid) => handleDeleteComment(p.id, cid)}
               />
             </div>
           ))}
@@ -65,6 +109,17 @@ export default function PublicationsFeed() {
         publication={selectedPublication}
         onClose={() => setSelectedPublication(null)}
       />
+
+      {toDelete && (
+        <ConfirmModal
+          title="Supprimer la publication"
+          message="Cette action est irreversible."
+          confirmText="Supprimer"
+          cancelText="Annuler"
+          onConfirm={confirmDelete}
+          onCancel={() => setToDelete(null)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow deleting publications and comments in `PublicationCard`
- enable comment deletion and publication removal in feed and user pages

## Testing
- `npm run lint` *(fails: useCallback and Tab unused errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872d9fe1bbc8331a5b61367880c08ea