### PR TITLE
Fix deletion modal alignment

### DIFF
--- a/web/src/app/evenement/page.tsx
+++ b/web/src/app/evenement/page.tsx
@@ -1,13 +1,13 @@
 /* app/(dashboard)/evenements/page.tsx */
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
 import { Plus } from "lucide-react";
 
 import AddEventModal from "@/components/AddEventModal";
 import EventCard from "@/components/EventCard";
 import EventModal from "@/components/EventModal";
-import ConfirmModal from "@/components/ConfirmModal";
+import DeleteConfirmModal from "@/components/DeleteConfirmModal";
 import { ApiEvent } from "@/types/evenement";
 
 import {
@@ -18,7 +18,7 @@ import {
 
 type Tab = "all" | "pending";
 export default function EventsPage() {
-  const [tab, setTab] = useState<"all" | "pending">("all");
+  const [tab, setTab] = useState<Tab>("all");
   const [events, setEvents] = useState<ApiEvent[]>([]);
   const [pendingEvents, setPendingEvents] = useState<ApiEvent[]>([]);
   const [loading, setLoading] = useState(true);
@@ -179,12 +179,10 @@ export default function EventsPage() {
         <EventModal event={selected} onClose={() => setSelected(null)} />
       )}
       {toDelete && (
-        <ConfirmModal
+        <DeleteConfirmModal
           title="Supprimer l'événement"
           message={`Supprimer « ${toDelete.titre} » ?`}
-          confirmText="Supprimer"
-          cancelText="Annuler"
-          onConfirm={confirmDelete}
+          onDelete={confirmDelete}
           onCancel={() => setToDelete(null)}
         />
       )}

--- a/web/src/app/publications/page.tsx
+++ b/web/src/app/publications/page.tsx
@@ -12,7 +12,7 @@ import PublicationCard from "@/components/PublicationCard";
 import AddPublicationModal from "@/components/AddPublicationModal";
 import PublicationModal from "@/components/PublicationModal";
 import { Plus } from "lucide-react";
-import ConfirmModal from "@/components/ConfirmModal";
+import DeleteConfirmModal from "@/components/DeleteConfirmModal";
 
 export default function PublicationsPage() {
   const [publications, setPublications] = useState<Publication[]>([]);
@@ -89,12 +89,10 @@ export default function PublicationsPage() {
       />
 
       {toDelete && (
-        <ConfirmModal
+        <DeleteConfirmModal
           title="Supprimer la publication"
           message="Cette action est irreversible."
-          confirmText="Supprimer"
-          cancelText="Annuler"
-          onConfirm={confirmDelete}
+          onDelete={confirmDelete}
           onCancel={() => setToDelete(null)}
         />
       )}

--- a/web/src/components/ConfirmModal.tsx
+++ b/web/src/components/ConfirmModal.tsx
@@ -19,7 +19,7 @@ export default function ConfirmModal({
 }: ConfirmModalProps) {
   return (
     <div
-      className="absolute inset-0 z-50 flex items-center justify-center bg-black/40"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
       onClick={(e) => e.target === e.currentTarget && onCancel()}
     >
       <motion.div

--- a/web/src/components/DeleteConfirmModal.tsx
+++ b/web/src/components/DeleteConfirmModal.tsx
@@ -1,0 +1,26 @@
+import ConfirmModal from "./ConfirmModal";
+
+interface DeleteConfirmModalProps {
+  title: string;
+  message: string;
+  onDelete: () => void;
+  onCancel?: () => void;
+}
+
+export default function DeleteConfirmModal({
+  title,
+  message,
+  onDelete,
+  onCancel,
+}: DeleteConfirmModalProps) {
+  return (
+    <ConfirmModal
+      title={title}
+      message={message}
+      confirmText="Supprimer"
+      cancelText="Annuler"
+      onConfirm={onDelete}
+      onCancel={onCancel ?? (() => {})}
+    />
+  );
+}

--- a/web/src/components/home/PublicationsFeed.tsx
+++ b/web/src/components/home/PublicationsFeed.tsx
@@ -11,7 +11,7 @@ import { Carousel } from "@/components/ui/carousel";
 import PublicationCard from "../PublicationCard";
 import PublicationModal from "../PublicationModal";
 import { addComment } from "@/lib/api/publication";
-import ConfirmModal from "../ConfirmModal";
+import DeleteConfirmModal from "../DeleteConfirmModal";
 
 export default function PublicationsFeed() {
   const [publications, setPublications] = useState<Publication[]>([]);
@@ -111,12 +111,10 @@ export default function PublicationsFeed() {
       />
 
       {toDelete && (
-        <ConfirmModal
+        <DeleteConfirmModal
           title="Supprimer la publication"
           message="Cette action est irreversible."
-          confirmText="Supprimer"
-          cancelText="Annuler"
-          onConfirm={confirmDelete}
+          onDelete={confirmDelete}
           onCancel={() => setToDelete(null)}
         />
       )}

--- a/web/src/components/profile/UserPublicationsList.tsx
+++ b/web/src/components/profile/UserPublicationsList.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/lib/api/publication";
 import { Publication } from "@/types/publication";
 import PublicationCard from "@/components/PublicationCard";
-import ConfirmModal from "@/components/ConfirmModal";
+import DeleteConfirmModal from "@/components/DeleteConfirmModal";
 
 export default function UserPublicationsList() {
   const { user } = useAuth();
@@ -90,12 +90,10 @@ export default function UserPublicationsList() {
       )}
 
       {toDelete && (
-        <ConfirmModal
+        <DeleteConfirmModal
           title="Supprimer la publication"
           message="Cette action est irreversible."
-          confirmText="Supprimer"
-          cancelText="Annuler"
-          onConfirm={confirmDelete}
+          onDelete={confirmDelete}
           onCancel={() => setToDelete(null)}
         />
       )}


### PR DESCRIPTION
## Summary
- ensure generic ConfirmModal uses fixed positioning
- add DeleteConfirmModal wrapper component
- use DeleteConfirmModal in event and publication pages
- adjust imports and remove unused code

## Testing
- `npx -y next@latest lint`

------
https://chatgpt.com/codex/tasks/task_e_68737728312483319696aff09cfb207d