### PR TITLE
Fix comment API usage in web app

### DIFF
--- a/web/src/app/publications/page.tsx
+++ b/web/src/app/publications/page.tsx
@@ -31,9 +31,17 @@ export default function PublicationsPage() {
 
   const handleComment = async (id: number, value: string) => {
     if (!value.trim()) return;
-    const pub = await addComment(id, value);
+    const comment = await addComment(id, value);
     setPublications((prev) =>
-      prev.map((p) => (p.id === id ? { ...p, ...pub } : p))
+      prev.map((p) =>
+        p.id === id
+          ? {
+              ...p,
+              commentaires: [...p.commentaires, comment],
+              nombres_commentaires: (p.nombres_commentaires || 0) + 1,
+            }
+          : p
+      )
     );
   };
 

--- a/web/src/components/home/PublicationsFeed.tsx
+++ b/web/src/components/home/PublicationsFeed.tsx
@@ -22,12 +22,28 @@ export default function PublicationsFeed() {
 
   const handleComment = async (id: number, value: string) => {
     if (!value.trim()) return;
-    const pub = await addComment(id, value);
+    const comment = await addComment(id, value);
     setPublications((prev) =>
-      prev.map((p) => (p.id === id ? { ...p, ...pub } : p))
+      prev.map((p) =>
+        p.id === id
+          ? {
+              ...p,
+              commentaires: [...p.commentaires, comment],
+              nombres_commentaires: (p.nombres_commentaires || 0) + 1,
+            }
+          : p
+      )
     );
     if (selectedPublication?.id === id) {
-      setSelectedPublication((prev) => (prev ? { ...prev, ...pub } : null));
+      setSelectedPublication((prev) =>
+        prev
+          ? {
+              ...prev,
+              commentaires: [...prev.commentaires, comment],
+              nombres_commentaires: (prev.nombres_commentaires || 0) + 1,
+            }
+          : null
+      );
     }
   };
 

--- a/web/src/components/profile/UserPublicationsList.tsx
+++ b/web/src/components/profile/UserPublicationsList.tsx
@@ -30,9 +30,17 @@ export default function UserPublicationsList() {
   const handleComment = async (id: number, value: string) => {
     if (!value.trim()) return;
     try {
-      const updatedPub = await addComment(id, value);
+      const comment = await addComment(id, value);
       setPublications((prev) =>
-        prev.map((p) => (p.id === id ? { ...p, commentaires: updatedPub.commentaires } : p))
+        prev.map((p) =>
+          p.id === id
+            ? {
+                ...p,
+                commentaires: [...p.commentaires, comment],
+                nombres_commentaires: (p.nombres_commentaires || 0) + 1,
+              }
+            : p
+        )
       );
     } catch (error) {
       console.error("Failed to add comment:", error);

--- a/web/src/lib/api/publication.ts
+++ b/web/src/lib/api/publication.ts
@@ -1,5 +1,5 @@
 import { api } from "./axios";
-import { Publication } from "@/types/publication";
+import { Publication, Commentaire } from "@/types/publication";
 
 export async function fetchPublications() {
   const res = await api.get<Publication[]>("/publications/fil/");
@@ -15,11 +15,12 @@ export async function deletePublication(id: number) {
   await api.delete(`/publications/${id}/supprimer/`);
 }
 
-export async function addComment(id: number, contenu: string) {
-  const res = await api.post(`/publications/${id}/commentaires/`, {
+export async function addComment(publication: number, contenu: string) {
+  const res = await api.post<Commentaire>("/publications/commenter/", {
+    publication,
     contenu,
   });
-  return res.data as Publication;
+  return res.data;
 }
 
 export async function deleteComment(id: number) {


### PR DESCRIPTION
## Summary
- update publication API to POST to `/publications/commenter/`
- adjust comment handlers to insert returned comment

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68737f53c38c83318f29d9bc45694372