### PR TITLE
Integrate user reporting in web app

### DIFF
--- a/web/src/app/profile/[username]/page.tsx
+++ b/web/src/app/profile/[username]/page.tsx
@@ -11,6 +11,7 @@ import { useAuth } from "@/lib/api/authContext";
 import { envoyerDemande } from "@/lib/api/mentorat";
 import { toast } from "@/components/ui/toast";
 import Link from "next/link";
+import ReportUserModal from "@/components/ReportUserModal";
 
 export default function UserProfilePage() {
   const params = useParams();
@@ -21,6 +22,7 @@ export default function UserProfilePage() {
   const [publications, setPublications] = useState<Publication[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [reportOpen, setReportOpen] = useState(false);
 
   useEffect(() => {
     if (username) {
@@ -114,6 +116,12 @@ export default function UserProfilePage() {
                   Mentor
                 </button>
               )}
+              <button
+                onClick={() => setReportOpen(true)}
+                className="btn btn-error flex-1"
+              >
+                Signaler
+              </button>
             </div>
           </div>
         </div>
@@ -133,6 +141,12 @@ export default function UserProfilePage() {
           <p>Cet utilisateur n&apos;a aucune publication.</p>
         )}
       </div>
+      {reportOpen && user && (
+        <ReportUserModal
+          userId={user.id}
+          onClose={() => setReportOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/ExternalProfileModal.tsx
+++ b/web/src/components/ExternalProfileModal.tsx
@@ -5,8 +5,10 @@ import Link from "next/link";
 import { useAuth } from "@/lib/api/authContext";
 import { envoyerDemande } from "@/lib/api/mentorat";
 import { toast } from "@/components/ui/toast";
+import ReportUserModal from "./ReportUserModal";
 
 interface UserProfile {
+  id: number;
   username: string;
   nom: string;
   prenom: string;
@@ -25,6 +27,7 @@ export default function ExternalProfileModal({
   onClose,
 }: ExternalProfileModalProps) {
   const { user: currentUser } = useAuth();
+  const [reportOpen, setReportOpen] = React.useState(false);
 
   const handleMentoratRequest = async () => {
     try {
@@ -112,8 +115,20 @@ export default function ExternalProfileModal({
                 Mentor
               </button>
             )}
+            <button
+              onClick={() => setReportOpen(true)}
+              className="btn btn-error flex-1"
+            >
+              Signaler
+            </button>
           </div>
         </div>
+        {reportOpen && (
+          <ReportUserModal
+            userId={user.id}
+            onClose={() => setReportOpen(false)}
+          />
+        )}
       </motion.div>
     </div>
   );

--- a/web/src/components/ReportUserModal.tsx
+++ b/web/src/components/ReportUserModal.tsx
@@ -1,0 +1,69 @@
+import { motion } from "framer-motion";
+import { useState, useEffect } from "react";
+import { createReport } from "@/lib/api/report";
+import { toast } from "@/components/ui/toast";
+
+interface ReportUserModalProps {
+  userId: number;
+  onClose(): void;
+}
+
+export default function ReportUserModal({ userId, onClose }: ReportUserModalProps) {
+  const [reason, setReason] = useState("comportement_inapproprié");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const esc = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [onClose]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      await createReport(userId, reason);
+      toast.success("Utilisateur signalé");
+      onClose();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <motion.form
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.25 }}
+        className="relative w-full max-w-sm bg-base-100 rounded-lg p-6 shadow-xl space-y-4"
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={handleSubmit}
+      >
+        <h2 className="text-lg font-bold">Signaler l'utilisateur</h2>
+        <select
+          className="select select-bordered w-full"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+        >
+          <option value="comportement_inapproprié">Comportement inapproprié</option>
+          <option value="contenu_inapproprié">Contenu inapproprié</option>
+          <option value="autre">Autre</option>
+        </select>
+        <div className="flex justify-end gap-2 pt-2">
+          <button type="button" className="btn" onClick={onClose}>
+            Annuler
+          </button>
+          <button type="submit" className="btn btn-error" disabled={submitting}>
+            {submitting ? <span className="loading loading-spinner"></span> : "Signaler"}
+          </button>
+        </div>
+      </motion.form>
+    </div>
+  );
+}

--- a/web/src/lib/api/users.ts
+++ b/web/src/lib/api/users.ts
@@ -1,6 +1,7 @@
 import { api } from "./axios";
 
 export interface UserProfile {
+  id: number;
   username: string;
   nom: string;
   prenom: string;


### PR DESCRIPTION
## Summary
- add modal to report a user
- allow opening report modal from external profile views
- expose user `id` in profile API

## Testing
- `npm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873ecd617948331bce33d4dc55798ce