### PR TITLE
Improve login error messaging

### DIFF
--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -33,8 +33,10 @@ export default function LoginPage() {
       toast.success("Connexion réussie");
     } catch (err) {
       if (axios.isAxiosError(err)) {
+        const errorData = err.response?.data;
         const message =
-          err.response?.data?.detail ||
+          errorData?.non_field_errors?.join(" \n") ||
+          errorData?.detail ||
           err.message ||
           "Identifiants incorrects";
         setServerError(message);

--- a/web/src/lib/api/axios.ts
+++ b/web/src/lib/api/axios.ts
@@ -29,6 +29,7 @@ api.interceptors.response.use(
   },
   (error) => {
     const message =
+      error.response?.data?.non_field_errors?.join(" \n") ||
       error.response?.data?.detail ||
       error.response?.data?.message ||
       error.message ||


### PR DESCRIPTION
## Summary
- show backend error message on login failures
- display API error messages from `non_field_errors` in axios interceptor

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68760ab96d1883319db125078e1f5783